### PR TITLE
[Reviewer: Andy] Fix HWM/LWM ordering

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Priority: optional
 # clearwater-infrastructure explicitly checks for packages of this name when
 # updating
 Maintainer: Project Clearwater Maintainers <maintainers@projectclearwater.org>
-Build-Depends: debhelper (>= 8.0.0)
+Build-Depends: debhelper (>= 8.0.0), build-essential, libsnmp-dev, libboost-dev, libzmq3-dev
 Standards-Version: 3.9.2
 Homepage: http://projectclearwater.org/
 

--- a/zmq_message_handler.cpp
+++ b/zmq_message_handler.cpp
@@ -79,18 +79,19 @@ void LatencyStatHandler::handle(std::vector<std::string> msgs)
   OID variance_oid = _root_oid;
   variance_oid.append("1.3");
 
-  OID lwm_oid = _root_oid;
-  lwm_oid.append("1.4");
-
   OID hwm_oid = _root_oid;
-  hwm_oid.append("1.5");
+  hwm_oid.append("1.4");
+
+  OID lwm_oid = _root_oid;
+  lwm_oid.append("1.5");
 
   // First two entries are the statistic name and the string "OK", so
   // skip them
   OIDMap new_subtree = {{average_oid, atoi(msgs[2].c_str())},
-    {variance_oid, atoi(msgs[3].c_str())},
-    {lwm_oid, atoi(msgs[3].c_str())},
-    {hwm_oid, atoi(msgs[4].c_str())}
+                        {variance_oid, atoi(msgs[3].c_str())},
+// Note that HWM and LWM are in a different order in SNMP and 0MQ
+                        {hwm_oid, atoi(msgs[5].c_str())},
+                        {lwm_oid, atoi(msgs[4].c_str())}
   };
 
   _tree->replace_subtree(_root_oid, new_subtree);


### PR DESCRIPTION
Whoops. The HWM and LWM are in a different order in SNMP and 0MQ.
