### PR TITLE
[Reviewer: Andy] Omit OIDs if no data to return (rather than returning genError)

### DIFF
--- a/custom_handler.cpp
+++ b/custom_handler.cpp
@@ -132,7 +132,7 @@ int clearwater_handler(netsnmp_mib_handler* handler,
         break;
 
       default:
-        snmp_log(LOG_ERR, "problem encountered in Clearwater handler: unsupported mode\n");
+        snmp_log(LOG_ERR, "problem encountered in Clearwater handler: unsupported mode %d", reqinfo->mode);
       }
     }
   }


### PR DESCRIPTION
Andy,

Please can you review my change to fix https://github.com/Metaswitch/clearwater-infrastructure/issues/59?  (Best to set `?w=1` on the end of the URI.)  There are basically 2 changes here.
-   Don't return `SNMP_ERR_GENERR` if our data is out of date.  Instead, just drop through and return `SNMP_ERR_NOERROR`.
-   Set the last_seen_time to 0 on initialization - it's misleading to say that we have values for the first 15s when we don't really.

I've live tested.

Matt
