### PR TITLE
Use ipc instead of tcp for 0MQ alarm interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,7 @@ test: run_test coverage vg coverage-check vg-check
 # Ignore failure here; it will be detected by Jenkins.
 .PHONY: run_test
 run_test: build_test | $(TEST_OUT_DIR)
+	mkdir -p /var/run/clearwater
 	rm -f $(TEST_XML)
 	rm -f $(OBJ_DIR_TEST)/*.gcda
 	$(TARGET_BIN_TEST) $(EXTRA_TEST_ARGS) --gtest_output=xml:$(TEST_XML)

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ test: run_test coverage vg coverage-check vg-check
 # Ignore failure here; it will be detected by Jenkins.
 .PHONY: run_test
 run_test: build_test | $(TEST_OUT_DIR)
-	mkdir -p /var/run/clearwater
+	(mkdir -p /var/run/clearwater; if [ $$? -ne 0 ]; then ( printf "\nFor tests to run, as root do the following:\n  $$ mkdir -p /var/run/clearwater\n  $$ chmod -R o+wr /var/run/clearwater\n" ); exit 1; fi)
 	rm -f $(TEST_XML)
 	rm -f $(OBJ_DIR_TEST)/*.gcda
 	$(TARGET_BIN_TEST) $(EXTRA_TEST_ARGS) --gtest_output=xml:$(TEST_XML)

--- a/alarm_req_listener.cpp
+++ b/alarm_req_listener.cpp
@@ -36,6 +36,9 @@
 #include <zmq.h>
 
 #include <sstream>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <signal.h>
 
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-includes.h>
@@ -123,11 +126,25 @@ bool AlarmReqListener::zmq_init_sck()
     return false;
   }
 
-  std::stringstream ss;
-  ss << "tcp://127.0.0.1:" << ZMQ_PORT; 
+  std::string sf = std::string("/var/run/clearwater/alarms");
+  std::string ss = std::string("ipc://" + sf);
+  snmp_log(LOG_INFO, "AlarmReqListener: ss='%s'", ss.c_str());
 
   int rc;
-  while (((rc = zmq_bind(_sck, ss.str().c_str())) == -1) && (errno == EINTR))
+  rc=remove(sf.c_str());
+  if (rc == -1)
+  {
+      if (errno != ENOENT)
+      {
+          snmp_log(LOG_ERR, "remove(%s) failed: %s - killing myself", sf.c_str(), strerror(errno));
+          kill(getpid(), SIGKILL);
+      }
+      else
+      {
+          snmp_log(LOG_ERR, "remove(%s) failed: %s", sf.c_str(), strerror(errno));
+      }
+  }
+  while (((rc = zmq_bind(_sck, ss.c_str())) == -1) && (errno == EINTR))
   {
     // Ignore possible errors due to a syscall being interrupted by a signal.
   }
@@ -136,6 +153,12 @@ bool AlarmReqListener::zmq_init_sck()
   {
     snmp_log(LOG_ERR, "zmq_bind failed: %s", zmq_strerror(errno));
     return false;
+  }
+
+  rc=chmod(sf.c_str(), 0777);
+  if (rc == -1)
+  {
+      snmp_log(LOG_ERR, "chmod(%s, 0777) failed: %s", sf.c_str(), strerror(errno));
   }
 
   return true;

--- a/alarm_req_listener.cpp
+++ b/alarm_req_listener.cpp
@@ -134,15 +134,15 @@ bool AlarmReqListener::zmq_init_sck()
   rc=remove(sf.c_str());
   if (rc == -1)
   {
-      if (errno != ENOENT)
-      {
-          snmp_log(LOG_ERR, "remove(%s) failed: %s - killing myself", sf.c_str(), strerror(errno));
-          kill(getpid(), SIGKILL);
-      }
-      else
-      {
-          snmp_log(LOG_ERR, "remove(%s) failed: %s", sf.c_str(), strerror(errno));
-      }
+    if (errno != ENOENT)
+    {
+      snmp_log(LOG_ERR, "remove(%s) failed: %s - killing myself", sf.c_str(), strerror(errno));
+      kill(getpid(), SIGKILL);
+    }
+    else
+    {
+      snmp_log(LOG_ERR, "remove(%s) failed: %s", sf.c_str(), strerror(errno));
+    }
   }
   while (((rc = zmq_bind(_sck, ss.c_str())) == -1) && (errno == EINTR))
   {

--- a/alarm_req_listener.cpp
+++ b/alarm_req_listener.cpp
@@ -131,7 +131,7 @@ bool AlarmReqListener::zmq_init_sck()
   snmp_log(LOG_INFO, "AlarmReqListener: ss='%s'", sck_url.c_str());
 
   int rc;
-  rc=remove(sck_url.c_str());
+  rc=remove(sck_file.c_str());
   if (rc == -1)
   {
     if (errno != ENOENT)

--- a/alarm_req_listener.cpp
+++ b/alarm_req_listener.cpp
@@ -126,25 +126,26 @@ bool AlarmReqListener::zmq_init_sck()
     return false;
   }
 
-  std::string sf = std::string("/var/run/clearwater/alarms");
-  std::string ss = std::string("ipc://" + sf);
-  snmp_log(LOG_INFO, "AlarmReqListener: ss='%s'", ss.c_str());
+  std::string sck_file = std::string("/var/run/clearwater/alarms");
+  std::string sck_url = std::string("ipc://" + sck_file);
+  snmp_log(LOG_INFO, "AlarmReqListener: ss='%s'", sck_url.c_str());
 
   int rc;
-  rc=remove(sf.c_str());
+  rc=remove(sck_url.c_str());
   if (rc == -1)
   {
     if (errno != ENOENT)
     {
-      snmp_log(LOG_ERR, "remove(%s) failed: %s - killing myself", sf.c_str(), strerror(errno));
+      snmp_log(LOG_ERR, "remove(%s) failed: %s - killing myself", sck_file.c_str(), strerror(errno));
       kill(getpid(), SIGKILL);
     }
     else
     {
-      snmp_log(LOG_ERR, "remove(%s) failed: %s", sf.c_str(), strerror(errno));
+      snmp_log(LOG_ERR, "remove(%s) failed: %s", sck_file.c_str(), strerror(errno));
     }
   }
-  while (((rc = zmq_bind(_sck, ss.c_str())) == -1) && (errno == EINTR))
+
+  while (((rc = zmq_bind(_sck, sck_url.c_str())) == -1) && (errno == EINTR))
   {
     // Ignore possible errors due to a syscall being interrupted by a signal.
   }
@@ -155,10 +156,10 @@ bool AlarmReqListener::zmq_init_sck()
     return false;
   }
 
-  rc=chmod(sf.c_str(), 0777);
+  rc=chmod(sck_file.c_str(), 0777);
   if (rc == -1)
   {
-      snmp_log(LOG_ERR, "chmod(%s, 0777) failed: %s", sf.c_str(), strerror(errno));
+    snmp_log(LOG_ERR, "chmod(%s, 0777) failed: %s", sck_file.c_str(), strerror(errno));
   }
 
   return true;

--- a/debian/postinst
+++ b/debian/postinst
@@ -53,6 +53,14 @@ set -e
 
 case "$1" in
     configure)
+        sed -ie '/mkdir -p \/var\/run\/clearwater\/stats/d' /etc/init.d/snmpd
+	sed -ie '/chmod -fR 0777 \/var\/run\/clearwater/d' /etc/init.d/snmpd
+	sed -ie '/^case/i \
+mkdir -p /var/run/clearwater/stats || true\
+chmod -fR 0777 /var/run/clearwater || true\
+'  /etc/init.d/snmpd
+	rm -f /etc/init.d/snmpde
+
         # Trigger an snmpd restart to load the sub-agent
         service snmpd restart || true
     ;;

--- a/debian/postinst
+++ b/debian/postinst
@@ -53,14 +53,6 @@ set -e
 
 case "$1" in
     configure)
-        sed -ie '/mkdir -p \/var\/run\/clearwater\/stats/d' /etc/init.d/snmpd
-	sed -ie '/chmod -fR 0777 \/var\/run\/clearwater/d' /etc/init.d/snmpd
-	sed -ie '/^case/i \
-mkdir -p /var/run/clearwater/stats || true\
-chmod -fR 0777 /var/run/clearwater || true\
-'  /etc/init.d/snmpd
-	rm -f /etc/init.d/snmpde
-
         # Trigger an snmpd restart to load the sub-agent
         service snmpd restart || true
     ;;


### PR DESCRIPTION
These changes are required for alarms to work in a separated mgmt/signalling network environment. The changes are similar in nature to those needed for statistics in that environment and have been tested in a multiple network environment in system test.