### PR TITLE
Reviewer AMC: Add Entry and ConnectionCount elements to OIDs

### DIFF
--- a/zmq_message_handler.cpp
+++ b/zmq_message_handler.cpp
@@ -52,6 +52,13 @@ void IPCountStatHandler::handle(std::vector<std::string> msgs)
     if (oid_addr.isValid())
     {
       OID this_oid = _root_oid;
+
+      // The root OIDs for the ConnectionCount tables (bonoConnectedSproutsTable,
+      // sproutConnectedHomersTable, sproutConnectedHomesteadsTable and
+      // mementoConnectedHomesteadsTable) don't contain the element for the
+      // table Entry (always "1") or the element for the ConnectionCount
+      // (always "3"), so insert these before adding the IP address index.
+      this_oid.append("1.3");
       this_oid.append(oid_addr);
 
       int connections_to_this_ip = atoi(it_val->c_str());


### PR DESCRIPTION
Tested by patching a sprout node (on which the "snmp" package has been installed, and the OID tables uploaded to enable reporting of textual OIDs) and then running the command 

snmpwalk -v2c -c clearwater localhost .1.2.826.0.1.1578918.9.3.3.1

to fetch the contents of sproutConnectedHomesteadsTable.  

This returned output in the expected format, namely

PROJECT-CLEARWATER-MIB::sproutHomesteadConnectionCount.ipv4."<homestead IP>" = ....

and not (erroneously)

PROJECT-CLEARWATER-MIB::sproutConnectedHomesteadsEntry.ipv6z.<homestead IP> = ...

as this test did previously
