### PR TITLE
[Reviewer: Matt] Scope changes

### DIFF
--- a/PROJECT-CLEARWATER-MIB
+++ b/PROJECT-CLEARWATER-MIB
@@ -586,14 +586,14 @@ sproutHomerLatencyCount OBJECT-TYPE
     DESCRIPTION "The total requests over the period."
     ::= { sproutHomerLatencyEntry 6 }
 
-homestead OBJECT IDENTIFIER ::= { sprout 3 }
+hss OBJECT IDENTIFIER ::= { sprout 3 }
 
 sproutConnectedHomesteadsTable OBJECT-TYPE
     SYNTAX SEQUENCE OF SproutConnectedHomesteadsEntry
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION "Statistics for each connected upstream Homestead node"
-    ::= { homestead 1 }
+    ::= { hss 1 }
 
 sproutConnectedHomesteadsEntry OBJECT-TYPE
     SYNTAX SproutConnectedHomesteadsEntry
@@ -641,7 +641,7 @@ sproutHomesteadLatencyTable OBJECT-TYPE
     DESCRIPTION "Latency of Homestead requests made by this Sprout
                  over a the given period.  Latency measured in
                  microseconds"
-    ::= { homestead 2 }
+    ::= { hss 2 }
 
 sproutHomesteadLatencyEntry OBJECT-TYPE
     SYNTAX      SproutHomesteadLatencyEntry
@@ -715,7 +715,7 @@ sproutMARLatencyTable OBJECT-TYPE
     DESCRIPTION "Latency of requests for MARs made by this Sprout
                  over the given period.  Latency measured in
                  microseconds"
-    ::= { homestead 3 }
+    ::= { hss 3 }
 
 sproutMARLatencyEntry OBJECT-TYPE
     SYNTAX      SproutMARLatencyEntry
@@ -789,7 +789,7 @@ sproutSARLatencyTable OBJECT-TYPE
     DESCRIPTION "Latency of requests for SARs made by this Sprout
                  over the given period.  Latency measured in
                  microseconds"
-    ::= { homestead 4 }
+    ::= { hss 4 }
 
 sproutSARLatencyEntry OBJECT-TYPE
     SYNTAX      SproutSARLatencyEntry
@@ -863,7 +863,7 @@ sproutUARLatencyTable OBJECT-TYPE
     DESCRIPTION "Latency of requests for user authentication made by this Sprout
                  over the given period.  Latency measured in
                  microseconds"
-    ::= { homestead 5 }
+    ::= { hss 5 }
 
 sproutUARLatencyEntry OBJECT-TYPE
     SYNTAX      SproutUARLatencyEntry
@@ -937,7 +937,7 @@ sproutLIRLatencyTable OBJECT-TYPE
     DESCRIPTION "Latency of location requests made by this Sprout
                  over the given period.  Latency measured in
                  microseconds"
-    ::= { homestead 6 }
+    ::= { hss 6 }
 
 sproutLIRLatencyEntry OBJECT-TYPE
     SYNTAX      SproutLIRLatencyEntry

--- a/PROJECT-CLEARWATER-MIB
+++ b/PROJECT-CLEARWATER-MIB
@@ -8,7 +8,7 @@ IMPORTS
 -- Module definition
 
   projectClearwater MODULE-IDENTITY
-        LAST-UPDATED "201411180000Z"
+        LAST-UPDATED "201506220000Z"
         ORGANIZATION "Metaswitch"
         CONTACT-INFO
           "Metaswitch
@@ -19,6 +19,9 @@ IMPORTS
            Tel: +44 20 8366 1177"
         DESCRIPTION  "This MIB module defines the Project
                       Clearwater statistics MIBs"
+
+        REVISION      "201506220000Z" -- 22 Jun 2015
+        DESCRIPTION   "Additional time scopes for Sprout/Bono stats"
 
         REVISION      "201411180000Z" -- 18 Nov 2014
         DESCRIPTION   "Addition of Memento statistics"
@@ -120,7 +123,9 @@ BonoLatencyEntry ::= SEQUENCE
 
 bonoLatencyScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1),
+                  scopeCurrent5MinutePeriod(2),
+                  scopePrevious5MinutePeriod(3)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -234,7 +239,9 @@ BonoIncomingRequestsEntry ::= SEQUENCE
 
 bonoIncomingRequestsScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1),
+                  scopeCurrent5MinutePeriod(2),
+                  scopePrevious5MinutePeriod(3)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -272,7 +279,9 @@ BonoRejectedOverloadEntry ::= SEQUENCE
 
 bonoRejectedOverloadScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1),
+                  scopeCurrent5MinutePeriod(2),
+                  scopePrevious5MinutePeriod(3)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -314,7 +323,9 @@ BonoQueueSizeEntry ::= SEQUENCE
 
 bonoQueueSizeScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1),
+                  scopeCurrent5MinutePeriod(2),
+                  scopePrevious5MinutePeriod(3)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -409,7 +420,9 @@ SproutLatencyEntry ::= SEQUENCE
 
 sproutLatencyScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1),
+                  scopeCurrent5MinutePeriod(2),
+                  scopePrevious5MinutePeriod(3)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -529,7 +542,9 @@ SproutHomerLatencyEntry ::= SEQUENCE
 
 sproutHomerLatencyScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1),
+                  scopeCurrent5MinutePeriod(2),
+                  scopePrevious5MinutePeriod(3)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -649,7 +664,9 @@ SproutHomesteadLatencyEntry ::= SEQUENCE
 
 sproutHomesteadLatencyScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1),
+                  scopeCurrent5MinutePeriod(2),
+                  scopePrevious5MinutePeriod(3)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -721,7 +738,9 @@ SproutMARLatencyEntry ::= SEQUENCE
 
 sproutMARLatencyScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1),
+                  scopeCurrent5MinutePeriod(2),
+                  scopePrevious5MinutePeriod(3)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -793,7 +812,9 @@ SproutSARLatencyEntry ::= SEQUENCE
 
 sproutSARLatencyScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1),
+                  scopeCurrent5MinutePeriod(2),
+                  scopePrevious5MinutePeriod(3)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -865,7 +886,9 @@ SproutUARLatencyEntry ::= SEQUENCE
 
 sproutUARLatencyScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1),
+                  scopeCurrent5MinutePeriod(2),
+                  scopePrevious5MinutePeriod(3)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -937,7 +960,9 @@ SproutLIRLatencyEntry ::= SEQUENCE
 
 sproutLIRLatencyScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1),
+                  scopeCurrent5MinutePeriod(2),
+                  scopePrevious5MinutePeriod(3)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -1003,7 +1028,9 @@ SproutIncomingRequestsEntry ::= SEQUENCE
 
 sproutIncomingRequestsScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1),
+                  scopeCurrent5MinutePeriod(2),
+                  scopePrevious5MinutePeriod(3)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -1041,7 +1068,9 @@ SproutRejectedOverloadEntry ::= SEQUENCE
 
 sproutRejectedOverloadScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1),
+                  scopeCurrent5MinutePeriod(2),
+                  scopePrevious5MinutePeriod(3)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -1083,7 +1112,9 @@ SproutQueueSizeEntry ::= SEQUENCE
 
 sproutQueueSizeScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1),
+                  scopeCurrent5MinutePeriod(2),
+                  scopePrevious5MinutePeriod(3)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -1208,7 +1239,7 @@ HomesteadLatencyEntry ::= SEQUENCE
 
 homesteadLatencyScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -1280,7 +1311,7 @@ HomesteadHSSLatencyEntry ::= SEQUENCE
 
 homesteadHSSLatencyScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -1352,7 +1383,7 @@ HomesteadCacheLatencyEntry ::= SEQUENCE
 
 homesteadCacheLatencyScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -1424,7 +1455,7 @@ HomesteadDigestLatencyEntry ::= SEQUENCE
 
 homesteadDigestLatencyScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -1496,7 +1527,7 @@ HomesteadSubscriptionLatencyEntry ::= SEQUENCE
 
 homesteadSubscriptionLatencyScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -1562,7 +1593,7 @@ HomesteadIncomingRequestsEntry ::= SEQUENCE
 
 homesteadIncomingRequestsScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -1600,7 +1631,7 @@ HomesteadRejectedOverloadEntry ::= SEQUENCE
 
 homesteadRejectedOverloadScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -1639,7 +1670,7 @@ HomesteadDiameterInvalidRealmEntry ::= SEQUENCE
 
 homesteadDiameterInvalidRealmScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -1677,7 +1708,7 @@ HomesteadDiameterInvalidHostEntry ::= SEQUENCE
 
 homesteadDiameterInvalidHostScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -1758,7 +1789,7 @@ CdivAsDiversionsEntry ::= SEQUENCE
 
 cdivAsDiversionsScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -1853,7 +1884,7 @@ MementoCallsRecordedTableEntry ::= SEQUENCE
 
 mementoCallsRecordedScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -1911,7 +1942,7 @@ MementoSIPCassandraReadLatencyEntry ::= SEQUENCE
 
 mementoSIPCassandraReadLatencyScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -1983,7 +2014,7 @@ MementoSIPCassandraWriteLatencyTableEntry ::= SEQUENCE
 
 mementoSIPCassandraWriteLatencyScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -2052,7 +2083,7 @@ MementoHTTPRequestTableEntry ::= SEQUENCE
 
 mementoHTTPRequestScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -2101,7 +2132,7 @@ MementoHTTPRequestLatencyTableEntry ::= SEQUENCE
 
 mementoHTTPRequestLatencyScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -2173,7 +2204,7 @@ MementoHTTPCassandraReadLatencyTableEntry ::= SEQUENCE
 
 mementoHTTPCassandraReadLatencyScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -2244,7 +2275,7 @@ MementoRetrievedCallRecordSizeTableEntry ::= SEQUENCE
 
 mementoRetrievedCallRecordSizeScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -2315,7 +2346,7 @@ MementoRetrievedCallRecordLengthTableEntry ::= SEQUENCE
 
 mementoRetrievedCallRecordLengthScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -2432,7 +2463,7 @@ MementoAuthAttemptTableEntry ::= SEQUENCE
 
 mementoAuthAttemptScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -2597,7 +2628,7 @@ AstaireBandwidthTableEntry ::= SEQUENCE
 
 astaireBandwidthScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -2810,7 +2841,7 @@ astaireConnectionBucketBandwidthBucketId OBJECT-TYPE
 
 astaireConnectionBucketBandwidthScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -2880,7 +2911,7 @@ ChronosTimersProcessedEntry ::= SEQUENCE
 
 chronosTimersProcessedScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -2918,7 +2949,7 @@ ChronosInvalidTimersProcessedEntry ::= SEQUENCE
 
 chronosInvalidTimersProcessedScope OBJECT-TYPE
     SYNTAX      INTEGER {
-                  scopeCurrent5SecondPeriod(1)
+                  scopePrevious5SecondPeriod(1)
                 }
     MAX-ACCESS  not-accessible
     STATUS      current

--- a/PROJECT-CLEARWATER-MIB
+++ b/PROJECT-CLEARWATER-MIB
@@ -571,14 +571,14 @@ sproutHomerLatencyCount OBJECT-TYPE
     DESCRIPTION "The total requests over the period."
     ::= { sproutHomerLatencyEntry 6 }
 
-hss OBJECT IDENTIFIER ::= { sprout 3 }
+homestead OBJECT IDENTIFIER ::= { sprout 3 }
 
 sproutConnectedHomesteadsTable OBJECT-TYPE
     SYNTAX SEQUENCE OF SproutConnectedHomesteadsEntry
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION "Statistics for each connected upstream Homestead node"
-    ::= { hss 1 }
+    ::= { homestead 1 }
 
 sproutConnectedHomesteadsEntry OBJECT-TYPE
     SYNTAX SproutConnectedHomesteadsEntry
@@ -626,7 +626,7 @@ sproutHomesteadLatencyTable OBJECT-TYPE
     DESCRIPTION "Latency of Homestead requests made by this Sprout
                  over a the given period.  Latency measured in
                  microseconds"
-    ::= { hss 2 }
+    ::= { homestead 2 }
 
 sproutHomesteadLatencyEntry OBJECT-TYPE
     SYNTAX      SproutHomesteadLatencyEntry
@@ -698,7 +698,7 @@ sproutMARLatencyTable OBJECT-TYPE
     DESCRIPTION "Latency of requests for MARs made by this Sprout
                  over the given period.  Latency measured in
                  microseconds"
-    ::= { hss 3 }
+    ::= { homestead 3 }
 
 sproutMARLatencyEntry OBJECT-TYPE
     SYNTAX      SproutMARLatencyEntry
@@ -770,7 +770,7 @@ sproutSARLatencyTable OBJECT-TYPE
     DESCRIPTION "Latency of requests for SARs made by this Sprout
                  over the given period.  Latency measured in
                  microseconds"
-    ::= { hss 4 }
+    ::= { homestead 4 }
 
 sproutSARLatencyEntry OBJECT-TYPE
     SYNTAX      SproutSARLatencyEntry
@@ -842,7 +842,7 @@ sproutUARLatencyTable OBJECT-TYPE
     DESCRIPTION "Latency of requests for user authentication made by this Sprout
                  over the given period.  Latency measured in
                  microseconds"
-    ::= { hss 5 }
+    ::= { homestead 5 }
 
 sproutUARLatencyEntry OBJECT-TYPE
     SYNTAX      SproutUARLatencyEntry
@@ -914,7 +914,7 @@ sproutLIRLatencyTable OBJECT-TYPE
     DESCRIPTION "Latency of location requests made by this Sprout
                  over the given period.  Latency measured in
                  microseconds"
-    ::= { hss 6 }
+    ::= { homestead 6 }
 
 sproutLIRLatencyEntry OBJECT-TYPE
     SYNTAX      SproutLIRLatencyEntry


### PR DESCRIPTION
Corresponding changes to https://github.com/Metaswitch/cpp-common/pull/311.

* My new code exposes three scopes for time-based tables (prev 5 seconds, current 5 minutes, prev 5 minutes) so I could make sure my code was sufficiently flexible. I've now updated this to match.
* I also took the opportunity to correct `scopeCurrent5SecondPeriod` to `scopePrevious5SecondPeriod` (which I think we agreed was more accurate even for existing stats).
* I noticed that there were some references to "hss" which should have been "homestead", so I've fixed those up.