### PR TITLE
Review AMC: Don't report the same value if SNMP GET performed for multiple OIDs

### DIFF
--- a/custom_handler.cpp
+++ b/custom_handler.cpp
@@ -113,7 +113,7 @@ int clearwater_handler(netsnmp_mib_handler* handler,
   {
     for(request = requests; request; request = request->next)
     {
-      OID this_oid(requests->requestvb->name, requests->requestvb->name_length);
+      OID this_oid(request->requestvb->name, request->requestvb->name_length);
       int outval;
       unsigned int retval;
       OID outoid;


### PR DESCRIPTION
Bug here is that if you issue an SNMP GET to a node specifying mulitple OIDs, you get the value of the first reported for all of them.

Fix tested live using snmpget with mulitple OIDs 