### PR TITLE
[Reviewer: Andy] Fix up smilint warnings

### DIFF
--- a/PROJECT-CLEARWATER-MIB
+++ b/PROJECT-CLEARWATER-MIB
@@ -3804,21 +3804,21 @@ callDiversionASGroup OBJECT-GROUP
 mementoSIP OBJECT IDENTIFIER ::= { memento 1 }
 
 mementoCallsRecordedTable OBJECT-TYPE
-    SYNTAX SEQUENCE OF MementoCallsRecordedTableEntry
+    SYNTAX SEQUENCE OF MementoCallsRecordedEntry
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Counts of call record creation outcomes for the given period."
     ::= { mementoSIP 1 }
 
-mementoCallsRecordedTableEntry OBJECT-TYPE
-    SYNTAX      MementoCallsRecordedTableEntry
+mementoCallsRecordedEntry OBJECT-TYPE
+    SYNTAX      MementoCallsRecordedEntry
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Counts of call record creation outcomes"
     INDEX       { mementoCallsRecordedScope }
     ::= { mementoCallsRecordedTable 1 }
 
-MementoCallsRecordedTableEntry ::= SEQUENCE
+MementoCallsRecordedEntry ::= SEQUENCE
 {
     mementoCallsRecordedScope            INTEGER,
     mementoCompletedCallsRecorded        Unsigned32,
@@ -3833,28 +3833,28 @@ mementoCallsRecordedScope OBJECT-TYPE
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "The period over which the statistics were collected."
-    ::= { mementoCallsRecordedTableEntry 1 }
+    ::= { mementoCallsRecordedEntry 1 }
 
 mementoCompletedCallsRecorded OBJECT-TYPE
     SYNTAX      Unsigned32
     MAX-ACCESS  read-only
     STATUS      current
     DESCRIPTION "The total number of successful calls recorded."
-    ::= { mementoCallsRecordedTableEntry 2 }
+    ::= { mementoCallsRecordedEntry 2 }
 
 mementoFailedCallsRecorded OBJECT-TYPE
     SYNTAX      Unsigned32
     MAX-ACCESS  read-only
     STATUS      current
     DESCRIPTION "The total number of failed call attempts recorded."
-    ::= { mementoCallsRecordedTableEntry 3 }
+    ::= { mementoCallsRecordedEntry 3 }
 
 mementoCallsNotRecordedDueToOverload OBJECT-TYPE
     SYNTAX      Unsigned32
     MAX-ACCESS  read-only
     STATUS      current
     DESCRIPTION "The total number of call records dropped due to overload."
-    ::= { mementoCallsRecordedTableEntry 4 }
+    ::= { mementoCallsRecordedEntry 4 }
 
 mementoSIPCassandraReadLatencyTable OBJECT-TYPE
     SYNTAX SEQUENCE OF MementoSIPCassandraReadLatencyEntry
@@ -3929,7 +3929,7 @@ mementoSIPCassandraReadLatencyCount OBJECT-TYPE
     ::= { mementoSIPCassandraReadLatencyEntry 6 }
 
 mementoSIPCassandraWriteLatencyTable OBJECT-TYPE
-    SYNTAX SEQUENCE OF MementoSIPCassandraWriteLatencyTableEntry
+    SYNTAX SEQUENCE OF MementoSIPCassandraWriteLatencyEntry
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION "The average, variance, LWM and HWM of Cassandra database write
@@ -3938,7 +3938,7 @@ mementoSIPCassandraWriteLatencyTable OBJECT-TYPE
     ::= { mementoSIP 3 }
 
 mementoSIPCassandraWriteLatencyEntry OBJECT-TYPE
-    SYNTAX      MementoSIPCassandraWriteLatencyTableEntry
+    SYNTAX      MementoSIPCassandraWriteLatencyEntry
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "The average, variance, LWM and HWM of Cassandra database write
@@ -3946,7 +3946,7 @@ mementoSIPCassandraWriteLatencyEntry OBJECT-TYPE
     INDEX       { mementoSIPCassandraWriteLatencyScope }
     ::= { mementoSIPCassandraWriteLatencyTable 1 }
 
-MementoSIPCassandraWriteLatencyTableEntry ::= SEQUENCE
+MementoSIPCassandraWriteLatencyEntry ::= SEQUENCE
 {
   mementoSIPCassandraWriteLatencyScope          INTEGER,
   mementoSIPCassandraWriteLatencyAverage        Unsigned32,
@@ -4139,22 +4139,22 @@ mementoOutgoingSIPTransactionsFailures OBJECT-TYPE
 mementoHTTP OBJECT IDENTIFIER ::= { memento 2 }
 
 mementoHTTPRequestTable OBJECT-TYPE
-    SYNTAX SEQUENCE OF MementoHTTPRequestTableEntry
+    SYNTAX SEQUENCE OF MementoHTTPRequestEntry
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Counts of HTTP requests and their outcomes for the given
                  period"
     ::= { mementoHTTP 1 }
 
-mementoHTTPRequestTableEntry OBJECT-TYPE
-    SYNTAX      MementoHTTPRequestTableEntry
+mementoHTTPRequestEntry OBJECT-TYPE
+    SYNTAX      MementoHTTPRequestEntry
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Counts of HTTP requests and their outcomes"
     INDEX       { mementoHTTPRequestScope }
     ::= { mementoHTTPRequestTable 1 }
 
-MementoHTTPRequestTableEntry ::= SEQUENCE
+MementoHTTPRequestEntry ::= SEQUENCE
 {
     mementoHTTPRequestScope            INTEGER,
     mementoHTTPRequestCount            Unsigned32,
@@ -4168,24 +4168,24 @@ mementoHTTPRequestScope OBJECT-TYPE
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "The period over which the statistics were collected."
-    ::= { mementoHTTPRequestTableEntry 1 }
+    ::= { mementoHTTPRequestEntry 1 }
 
 mementoHTTPRequestCount OBJECT-TYPE
     SYNTAX      Unsigned32
     MAX-ACCESS  read-only
     STATUS      current
     DESCRIPTION "The total number of HTTP requests received."
-    ::= { mementoHTTPRequestTableEntry 2 }
+    ::= { mementoHTTPRequestEntry 2 }
 
 mementoHTTPRejectedDueToOverload OBJECT-TYPE
     SYNTAX      Unsigned32
     MAX-ACCESS  read-only
     STATUS      current
     DESCRIPTION "The total number of HTTP requests rejected due to overload."
-    ::= { mementoHTTPRequestTableEntry 3 }
+    ::= { mementoHTTPRequestEntry 3 }
 
 mementoHTTPRequestLatencyTable OBJECT-TYPE
-    SYNTAX SEQUENCE OF MementoHTTPRequestLatencyTableEntry
+    SYNTAX SEQUENCE OF MementoHTTPRequestLatencyEntry
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION "Latency of HTTP call record retrieval requests over the given
@@ -4193,14 +4193,14 @@ mementoHTTPRequestLatencyTable OBJECT-TYPE
     ::= { mementoHTTP 2 }
 
 mementoHTTPRequestLatencyEntry OBJECT-TYPE
-    SYNTAX      MementoHTTPRequestLatencyTableEntry
+    SYNTAX      MementoHTTPRequestLatencyEntry
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "The average, variance, LWM and HWM of HTTP call retrieval latency"
     INDEX       { mementoHTTPRequestLatencyScope }
     ::= { mementoHTTPRequestLatencyTable 1 }
 
-MementoHTTPRequestLatencyTableEntry ::= SEQUENCE
+MementoHTTPRequestLatencyEntry ::= SEQUENCE
 {
   mementoHTTPRequestLatencyScope          INTEGER,
   mementoHTTPRequestLatencyAverage        Unsigned32,
@@ -4255,7 +4255,7 @@ mementoHTTPRequestLatencyCount OBJECT-TYPE
     ::= { mementoHTTPRequestLatencyEntry 6 }
 
 mementoHTTPCassandraReadLatencyTable OBJECT-TYPE
-    SYNTAX SEQUENCE OF MementoHTTPCassandraReadLatencyTableEntry
+    SYNTAX SEQUENCE OF MementoHTTPCassandraReadLatencyEntry
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION "The average, variance, LWM and HWM of Cassandra database read
@@ -4264,7 +4264,7 @@ mementoHTTPCassandraReadLatencyTable OBJECT-TYPE
     ::= { mementoHTTP 3 }
 
 mementoHTTPCassandraReadLatencyEntry OBJECT-TYPE
-    SYNTAX      MementoHTTPCassandraReadLatencyTableEntry
+    SYNTAX      MementoHTTPCassandraReadLatencyEntry
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "The average, variance, LWM and HWM of Cassandra database read
@@ -4272,7 +4272,7 @@ mementoHTTPCassandraReadLatencyEntry OBJECT-TYPE
     INDEX       { mementoHTTPCassandraReadLatencyScope }
     ::= { mementoHTTPCassandraReadLatencyTable 1 }
 
-MementoHTTPCassandraReadLatencyTableEntry ::= SEQUENCE
+MementoHTTPCassandraReadLatencyEntry ::= SEQUENCE
 {
   mementoHTTPCassandraReadLatencyScope          INTEGER,
   mementoHTTPCassandraReadLatencyAverage        Unsigned32,
@@ -4327,7 +4327,7 @@ mementoHTTPCassandraReadLatencyCount OBJECT-TYPE
     ::= { mementoHTTPCassandraReadLatencyEntry 6 }
 
 mementoRetrievedCallRecordSizeTable OBJECT-TYPE
-    SYNTAX SEQUENCE OF MementoRetrievedCallRecordSizeTableEntry
+    SYNTAX SEQUENCE OF MementoRetrievedCallRecordSizeEntry
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION "Average, variance, HWM and LWM of the size (in kB) of call records
@@ -4335,7 +4335,7 @@ mementoRetrievedCallRecordSizeTable OBJECT-TYPE
     ::= { mementoHTTP 4 }
 
 mementoRetrievedCallRecordSizeEntry OBJECT-TYPE
-    SYNTAX      MementoRetrievedCallRecordSizeTableEntry
+    SYNTAX      MementoRetrievedCallRecordSizeEntry
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Average, variance, HWM and LWM of the size (in kB) of call records
@@ -4343,7 +4343,7 @@ mementoRetrievedCallRecordSizeEntry OBJECT-TYPE
     INDEX       { mementoRetrievedCallRecordSizeScope }
     ::= { mementoRetrievedCallRecordSizeTable 1 }
 
-MementoRetrievedCallRecordSizeTableEntry ::= SEQUENCE
+MementoRetrievedCallRecordSizeEntry ::= SEQUENCE
 {
   mementoRetrievedCallRecordSizeScope          INTEGER,
   mementoRetrievedCallRecordSizeAverage        Unsigned32,
@@ -4398,7 +4398,7 @@ mementoRetrievedCallRecordSizeCount OBJECT-TYPE
     ::= { mementoRetrievedCallRecordSizeEntry 6 }
 
 mementoRetrievedCallRecordLengthTable OBJECT-TYPE
-    SYNTAX SEQUENCE OF MementoRetrievedCallRecordLengthTableEntry
+    SYNTAX SEQUENCE OF MementoRetrievedCallRecordLengthEntry
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION "Average, variance, HWM and LWM of the length (# of records) of call
@@ -4406,7 +4406,7 @@ mementoRetrievedCallRecordLengthTable OBJECT-TYPE
     ::= { mementoHTTP 5 }
 
 mementoRetrievedCallRecordLengthEntry OBJECT-TYPE
-    SYNTAX      MementoRetrievedCallRecordLengthTableEntry
+    SYNTAX      MementoRetrievedCallRecordLengthEntry
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Average, variance, HWM and LWM of the length (# of records) of call
@@ -4414,7 +4414,7 @@ mementoRetrievedCallRecordLengthEntry OBJECT-TYPE
     INDEX       { mementoRetrievedCallRecordLengthScope }
     ::= { mementoRetrievedCallRecordLengthTable 1 }
 
-MementoRetrievedCallRecordLengthTableEntry ::= SEQUENCE
+MementoRetrievedCallRecordLengthEntry ::= SEQUENCE
 {
   mementoRetrievedCallRecordLengthScope          INTEGER,
   mementoRetrievedCallRecordLengthAverage        Unsigned32,
@@ -4517,21 +4517,21 @@ mementoHomesteadConnectionCount OBJECT-TYPE
     ::= { mementoConnectedHomesteadsEntry 3 }
 
 mementoAuthAttemptTable OBJECT-TYPE
-    SYNTAX SEQUENCE OF MementoAuthAttemptTableEntry
+    SYNTAX SEQUENCE OF MementoAuthAttemptEntry
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION "Counts of authentication attempts over the given period."
     ::= { mementoAuthProxy 2 }
 
 mementoAuthAttemptEntry OBJECT-TYPE
-    SYNTAX      MementoAuthAttemptTableEntry
+    SYNTAX      MementoAuthAttemptEntry
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Counts of authentication attempts over the given period."
     INDEX       { mementoAuthAttemptScope }
     ::= { mementoAuthAttemptTable 1 }
 
-MementoAuthAttemptTableEntry ::= SEQUENCE
+MementoAuthAttemptEntry ::= SEQUENCE
 {
   mementoAuthAttemptScope          INTEGER,
   mementoAuthChallengeCount        Unsigned32,
@@ -4692,21 +4692,21 @@ astaireDataResynchronized OBJECT-TYPE
     ::= { astaire 4 }
 
 astaireBandwidthTable OBJECT-TYPE
-    SYNTAX SEQUENCE OF AstaireBandwidthTableEntry
+    SYNTAX SEQUENCE OF AstaireBandwidthEntry
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Resynchronization bandwidth for the given period."
     ::= { astaire 5 }
 
-astaireBandwidthTableEntry OBJECT-TYPE
-    SYNTAX      AstaireBandwidthTableEntry
+astaireBandwidthEntry OBJECT-TYPE
+    SYNTAX      AstaireBandwidthEntry
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Resynchronization bandwidth."
     INDEX       { astaireBandwidthScope }
     ::= { astaireBandwidthTable 1 }
 
-AstaireBandwidthTableEntry ::= SEQUENCE
+AstaireBandwidthEntry ::= SEQUENCE
 {
     astaireBandwidthScope          INTEGER,
     astaireBandwidth               Unsigned32
@@ -4719,24 +4719,24 @@ astaireBandwidthScope OBJECT-TYPE
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "The period over which the statistics were collected."
-    ::= { astaireBandwidthTableEntry 1 }
+    ::= { astaireBandwidthEntry 1 }
 
 astaireBandwidth OBJECT-TYPE
     SYNTAX      Unsigned32
     MAX-ACCESS  read-only
     STATUS      current
     DESCRIPTION "Resynchronization bandwidth (bytes per second) over the period."
-    ::= { astaireBandwidthTableEntry 2 }
+    ::= { astaireBandwidthEntry 2 }
 
 astaireConnectionTable OBJECT-TYPE
-    SYNTAX SEQUENCE OF AstaireConnectionTableEntry
+    SYNTAX SEQUENCE OF AstaireConnectionEntry
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Resynchronization statistics on a per-connection basis."
     ::= { astaire 6 }
 
-astaireConnectionTableEntry OBJECT-TYPE
-    SYNTAX      AstaireConnectionTableEntry
+astaireConnectionEntry OBJECT-TYPE
+    SYNTAX      AstaireConnectionEntry
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Resynchronization statistics for a specific connection.  Entries only
@@ -4747,7 +4747,7 @@ astaireConnectionTableEntry OBJECT-TYPE
             astaireConnectionInetPort      }
     ::= { astaireConnectionTable 1 }
 
-AstaireConnectionTableEntry ::= SEQUENCE
+AstaireConnectionEntry ::= SEQUENCE
 {
   astaireConnectionInetAddrType           InetAddressType,
   astaireConnectionInetAddr               InetAddress,
@@ -4761,21 +4761,21 @@ astaireConnectionInetAddrType OBJECT-TYPE
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Inet address type of the connection peer"
-    ::= { astaireConnectionTableEntry 1 }
+    ::= { astaireConnectionEntry 1 }
 
 astaireConnectionInetAddr OBJECT-TYPE
     SYNTAX      InetAddress (SIZE (1..16))
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Inet address of the connection peer"
-    ::= { astaireConnectionTableEntry 2 }
+    ::= { astaireConnectionEntry 2 }
 
 astaireConnectionInetPort OBJECT-TYPE
     SYNTAX      Unsigned32
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Port of the connection peer"
-    ::= { astaireConnectionTableEntry 3 }
+    ::= { astaireConnectionEntry 3 }
 
 astaireConnectionBucketsNeedingResync OBJECT-TYPE
     SYNTAX      Unsigned32
@@ -4783,7 +4783,7 @@ astaireConnectionBucketsNeedingResync OBJECT-TYPE
     STATUS      current
     DESCRIPTION "Count of buckets needing to be synchronized over this
                  connection for the current resynchronization operation."
-    ::= { astaireConnectionTableEntry 4 }
+    ::= { astaireConnectionEntry 4 }
 
 astaireConnectionBucketsResynchronized OBJECT-TYPE
     SYNTAX      Unsigned32
@@ -4791,18 +4791,18 @@ astaireConnectionBucketsResynchronized OBJECT-TYPE
     STATUS      current
     DESCRIPTION "Number of buckets already resynchronized over this connection
                  during the current resynchronization operation."
-    ::= { astaireConnectionTableEntry 5 }
+    ::= { astaireConnectionEntry 5 }
 
 astaireConnectionBucketTable OBJECT-TYPE
-    SYNTAX SEQUENCE OF AstaireConnectionBucketTableEntry
+    SYNTAX SEQUENCE OF AstaireConnectionBucketEntry
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Resynchronization statistics on a per-connection and
                  per-bucket basis."
     ::= { astaire 7 }
 
-astaireConnectionBucketTableEntry OBJECT-TYPE
-    SYNTAX      AstaireConnectionBucketTableEntry
+astaireConnectionBucketEntry OBJECT-TYPE
+    SYNTAX      AstaireConnectionBucketEntry
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Resynchronization statistics for a specific connection and
@@ -4813,7 +4813,7 @@ astaireConnectionBucketTableEntry OBJECT-TYPE
             astaireConnectionBucketId }
     ::= { astaireConnectionBucketTable 1 }
 
-AstaireConnectionBucketTableEntry ::= SEQUENCE
+AstaireConnectionBucketEntry ::= SEQUENCE
 {
   astaireConnectionBucketInetAddrType           InetAddressType,
   astaireConnectionBucketInetAddr               InetAddress,
@@ -4828,28 +4828,28 @@ astaireConnectionBucketInetAddrType OBJECT-TYPE
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Inet address type of the connection peer"
-    ::= { astaireConnectionBucketTableEntry 1 }
+    ::= { astaireConnectionBucketEntry 1 }
 
 astaireConnectionBucketInetAddr OBJECT-TYPE
     SYNTAX      InetAddress (SIZE (1..16))
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Inet address of the connection peer"
-    ::= { astaireConnectionBucketTableEntry 2 }
+    ::= { astaireConnectionBucketEntry 2 }
 
 astaireConnectionBucketInetPort OBJECT-TYPE
     SYNTAX      Unsigned32
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Port of the connection peer"
-    ::= { astaireConnectionBucketTableEntry 3 }
+    ::= { astaireConnectionBucketEntry 3 }
 
 astaireConnectionBucketId OBJECT-TYPE
     SYNTAX      Unsigned32
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Identifier of this bucket."
-    ::= { astaireConnectionBucketTableEntry 4 }
+    ::= { astaireConnectionBucketEntry 4 }
 
 astaireConnectionBucketEntriesResynchronized OBJECT-TYPE
     SYNTAX      Unsigned32
@@ -4857,7 +4857,7 @@ astaireConnectionBucketEntriesResynchronized OBJECT-TYPE
     STATUS      current
     DESCRIPTION "Number of entries already resynchronized during the current
                  resynchronization operation on this connection and bucket."
-    ::= { astaireConnectionBucketTableEntry 5 }
+    ::= { astaireConnectionBucketEntry 5 }
 
 astaireConnectionBucketDataResynchronized OBJECT-TYPE
     SYNTAX      Unsigned32
@@ -4865,17 +4865,17 @@ astaireConnectionBucketDataResynchronized OBJECT-TYPE
     STATUS      current
     DESCRIPTION "Amout of data (in bytes) already resynchronized during the current
                  resynchronization operation on this connection and bucket."
-    ::= { astaireConnectionBucketTableEntry 6 }
+    ::= { astaireConnectionBucketEntry 6 }
 
 astaireConnectionBucketBandwidthTable OBJECT-TYPE
-    SYNTAX SEQUENCE OF AstaireConnectionBucketBandwidthTableEntry
+    SYNTAX SEQUENCE OF AstaireConnectionBucketBandwidthEntry
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Resynchronization bandwidth for this bucket for the given period."
     ::= { astaire 8 }
 
-astaireConnectionBucketBandwidthTableEntry OBJECT-TYPE
-    SYNTAX      AstaireConnectionBucketBandwidthTableEntry
+astaireConnectionBucketBandwidthEntry OBJECT-TYPE
+    SYNTAX      AstaireConnectionBucketBandwidthEntry
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Resynchronization bandwidth for this bucket."
@@ -4886,7 +4886,7 @@ astaireConnectionBucketBandwidthTableEntry OBJECT-TYPE
             astaireConnectionBucketBandwidthScope }
     ::= { astaireConnectionBucketBandwidthTable 1 }
 
-AstaireConnectionBucketBandwidthTableEntry ::= SEQUENCE
+AstaireConnectionBucketBandwidthEntry ::= SEQUENCE
 {
     astaireConnectionBucketBandwidthScope        INTEGER,
     astaireConnectionBucketBandwidth             Unsigned32
@@ -4899,14 +4899,14 @@ astaireConnectionBucketBandwidthScope OBJECT-TYPE
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "The period over which the statistics were collected."
-    ::= { astaireConnectionBucketBandwidthTableEntry 5 }
+    ::= { astaireConnectionBucketBandwidthEntry 5 }
 
 astaireConnectionBucketBandwidth OBJECT-TYPE
     SYNTAX      Unsigned32
     MAX-ACCESS  read-only
     STATUS      current
     DESCRIPTION "Resynchronization bandwidth (bytes per second) over the period."
-    ::= { astaireConnectionBucketBandwidthTableEntry 6 }
+    ::= { astaireConnectionBucketBandwidthEntry 6 }
 
 astaireGroup OBJECT-GROUP
     OBJECTS {

--- a/PROJECT-CLEARWATER-MIB
+++ b/PROJECT-CLEARWATER-MIB
@@ -9,7 +9,7 @@ IMPORTS
 -- Module definition
 
   projectClearwater MODULE-IDENTITY
-        LAST-UPDATED "201506220000Z"
+        LAST-UPDATED "201510070000Z"
         ORGANIZATION "Metaswitch"
         CONTACT-INFO
           "Metaswitch
@@ -20,6 +20,9 @@ IMPORTS
            Tel: +44 20 8366 1177"
         DESCRIPTION  "This MIB module defines the Project
                       Clearwater statistics MIBs"
+
+        REVISION      "201510070000Z" -- 07 Oct 2015
+        DESCRIPTION   "Fix warning messages about naming conventions"
 
         REVISION      "201506220000Z" -- 22 Jun 2015
         DESCRIPTION   "Additional time scopes for Sprout/Bono stats"

--- a/PROJECT-CLEARWATER-MIB
+++ b/PROJECT-CLEARWATER-MIB
@@ -4816,12 +4816,11 @@ astaireConnectionBucketTableEntry OBJECT-TYPE
 AstaireConnectionBucketTableEntry ::= SEQUENCE
 {
   astaireConnectionBucketInetAddrType           InetAddressType,
-  astaireConnectionBucketInetAddr               InetAddress (SIZE (1..16)),
+  astaireConnectionBucketInetAddr               InetAddress,
   astaireConnectionBucketInetPort               Unsigned32,
   astaireConnectionBucketId                     Unsigned32,
   astaireConnectionBucketEntriesResynchronized  Unsigned32,
-  astaireConnectionBucketDataResynchronized     Unsigned32,
-  astaireConnectionBucketBandwidthTable         SEQUENCE OF AstaireConnectionBucketBandwidthTableEntry
+  astaireConnectionBucketDataResynchronized     Unsigned32
 }
 
 astaireConnectionBucketInetAddrType OBJECT-TYPE
@@ -4880,50 +4879,18 @@ astaireConnectionBucketBandwidthTableEntry OBJECT-TYPE
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION "Resynchronization bandwidth for this bucket."
-    INDEX       { astaireConnectionBucketBandwidthInetAddrType,
-                  astaireConnectionBucketBandwidthInetAddr,
-                  astaireConnectionBucketBandwidthInetPort,
-                  astaireConnectionBucketBandwidthBucketId,
-                  astaireConnectionBucketBandwidthScope }
+    INDEX { astaireConnectionBucketInetAddrType,
+            astaireConnectionBucketInetAddr,
+            astaireConnectionBucketInetPort,
+            astaireConnectionBucketId,
+            astaireConnectionBucketBandwidthScope }
     ::= { astaireConnectionBucketBandwidthTable 1 }
 
 AstaireConnectionBucketBandwidthTableEntry ::= SEQUENCE
 {
-    astaireConnectionBucketBandwidthInetAddrType InetAddressType,
-    astaireConnectionBucketBandwidthInetAddr     InetAddress (SIZE (1..16)),
-    astaireConnectionBucketBandwidthInetPort     Unsigned32,
-    astaireConnectionBucketBandwidthBucketId     Unsigned32,
     astaireConnectionBucketBandwidthScope        INTEGER,
     astaireConnectionBucketBandwidth             Unsigned32
 }
-
-astaireConnectionBucketBandwidthInetAddrType OBJECT-TYPE
-    SYNTAX      InetAddressType
-    MAX-ACCESS  not-accessible
-    STATUS      current
-    DESCRIPTION "Inet address type of the connection peer"
-    ::= { astaireConnectionBucketBandwidthTableEntry 1 }
-
-astaireConnectionBucketBandwidthInetAddr OBJECT-TYPE
-    SYNTAX      InetAddress (SIZE (1..16))
-    MAX-ACCESS  not-accessible
-    STATUS      current
-    DESCRIPTION "Inet address of the connection peer"
-    ::= { astaireConnectionBucketBandwidthTableEntry 2 }
-
-astaireConnectionBucketBandwidthInetPort OBJECT-TYPE
-    SYNTAX      Unsigned32
-    MAX-ACCESS  not-accessible
-    STATUS      current
-    DESCRIPTION "Port of the connection peer"
-    ::= { astaireConnectionBucketBandwidthTableEntry 3 }
-
-astaireConnectionBucketBandwidthBucketId OBJECT-TYPE
-    SYNTAX      Unsigned32
-    MAX-ACCESS  not-accessible
-    STATUS      current
-    DESCRIPTION "Identifier of this bucket."
-    ::= { astaireConnectionBucketBandwidthTableEntry 4 }
 
 astaireConnectionBucketBandwidthScope OBJECT-TYPE
     SYNTAX      INTEGER {
@@ -4947,22 +4914,16 @@ astaireGroup OBJECT-GROUP
         astaireBucketsResynchronized,
         astaireEntriesResynchronized,
         astaireDataResynchronized,
-        astaireBandwidthScope,
         astaireBandwidth,
-        astaireConnectionInetAddrType,
-        astaireConnectionInetAddr,
-        astaireConnectionInetPort,
         astaireConnectionBucketsNeedingResync,
         astaireConnectionBucketsResynchronized,
-        astaireConnectionBucketId,
         astaireConnectionBucketEntriesResynchronized,
         astaireConnectionBucketDataResynchronized,
-        astaireConnectionBucketBandwidthScope,
         astaireConnectionBucketBandwidth
     }
     STATUS      current
     DESCRIPTION "Statistics exposed by Astaire"
-    ::= { projectClearwaterObjectGroups 6 }
+    ::= { projectClearwaterObjectGroups 8 }
 
 -- Chronos Entries
 
@@ -5072,11 +5033,11 @@ chronosRegEntry OBJECT-TYPE
 
 ChronosRegEntry ::= SEQUENCE
 {
-  chronosRegScope        INTEGER
+  chronosRegScope        INTEGER,
   chronosRegAverage      Unsigned32,
   chronosRegVariance     Unsigned32,
   chronosRegHWM          Unsigned32,
-  chronosRegLWM          Unsigned32,
+  chronosRegLWM          Unsigned32
 }
 
 chronosRegScope OBJECT-TYPE
@@ -5144,11 +5105,11 @@ chronosCallEntry OBJECT-TYPE
 
 ChronosCallEntry ::= SEQUENCE
 {
-  chronosCallScope        INTEGER
+  chronosCallScope        INTEGER,
   chronosCallAverage      Unsigned32,
   chronosCallVariance     Unsigned32,
   chronosCallHWM          Unsigned32,
-  chronosCallLWM          Unsigned32,
+  chronosCallLWM          Unsigned32
 }
 
 chronosCallScope OBJECT-TYPE


### PR DESCRIPTION
Can you review this fix, to make `smilint ./PROJECT-CLEARWATER-MIB -l 5` run cleanly?

It:
* fixes up some rogue commas
* doesn't list inaccessible objects in astaireGroup
* reworks the AstaireConnectionBucketBandwidthTable, following the guidance in http://stackoverflow.com/questions/2510211/snmp-asn-1-mib-definitions-referencing-a-table-within-a-table that nested tables should just be indexed by the parent table's index as well as their own

I'll also change Jenkins to run that smilint command and fail the build if it fails.