### PR TITLE
[Reviewer: Matt] Control the alarm agent and snmpd through monit

### DIFF
--- a/debian/clearwater-snmp-alarm-agent.postinst
+++ b/debian/clearwater-snmp-alarm-agent.postinst
@@ -55,10 +55,15 @@ case "$1" in
     configure)
 
         install -D --mode=0644 /usr/share/clearwater/conf/alarm_agent.monit /etc/monit/conf.d/
+
         # Force monit to reload its configuration
         reload clearwater-monit || true
+
         # Trigger an snmpd restart to load the sub-agent
-        service snmpd restart || true
+        service snmpd stop || true
+
+        # Restart the service
+        service clearwater-snmp-alarm-agent stop || true
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/clearwater-snmp-alarm-agent.postrm
+++ b/debian/clearwater-snmp-alarm-agent.postrm
@@ -41,5 +41,5 @@ rm -f /etc/monit/conf.d/alarm_agent.monit
 # Force monit to reload its configuration
 reload clearwater-monit || true
 
-# Trigger an snmpd restart to unload the sub-agent
-service snmpd restart || true
+# Trigger an snmpd stop to unload the sub-agent
+service snmpd stop || true

--- a/debian/clearwater-snmp-alarm-agent.postrm
+++ b/debian/clearwater-snmp-alarm-agent.postrm
@@ -41,5 +41,5 @@ rm -f /etc/monit/conf.d/alarm_agent.monit
 # Force monit to reload its configuration
 reload clearwater-monit || true
 
-# Trigger an snmpd stop to unload the sub-agent
+# Trigger an snmpd restart to unload the sub-agent
 service snmpd stop || true

--- a/debian/clearwater-snmp-handler-astaire.postinst
+++ b/debian/clearwater-snmp-handler-astaire.postinst
@@ -54,7 +54,7 @@ set -e
 case "$1" in
     configure)
         # Trigger an snmpd restart to load the sub-agent
-        service snmpd restart || true
+        service snmpd stop || true
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/clearwater-snmp-handler-astaire.postrm
+++ b/debian/clearwater-snmp-handler-astaire.postrm
@@ -4,5 +4,5 @@ if [ "$1" = "purge" ] ; then
 fi
 # End automatically added section
 
-service snmpd restart
+service snmpd stop
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -54,7 +54,7 @@ set -e
 case "$1" in
     configure)
         # Trigger an snmpd restart to load the sub-agent
-        service snmpd restart || true
+        service snmpd stop || true
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/postrm
+++ b/debian/postrm
@@ -4,5 +4,5 @@ if [ "$1" = "purge" ] ; then
 fi
 # End automatically added section
 
-service snmpd restart
+service snmpd stop
 

--- a/debian/rules
+++ b/debian/rules
@@ -26,4 +26,8 @@ override_dh_auto_test:
 override_dh_auto_install:
 	mkdir debian/tmp
 
+# Don't start - monit does that for us.
+override_dh_installinit:
+	dh_installinit --no-start -u"defaults 60 40"
+
 override_dh_shlibdeps:


### PR DESCRIPTION
Matt, can you review these changes to keep the alarm agent and snmp under monit's control. 
Tested by installing and checking that nothing obviously broke

Part of the fix for #98 