### PR TITLE
[Reviewer: Alex] Use common logging and SNMP infrastructure, and log on each alarm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ TARGET_TEST := handler_test
 
 TARGET_SOURCES := alarmdefinition.cpp \
                   json_alarms.cpp \
+                  log.cpp \
+                  logger.cpp \
+                  snmp_agent.cpp \
                   alarm_table_defs.cpp \
                   alarm_req_listener.cpp \
                   alarm_trap_sender.cpp \
@@ -55,8 +58,6 @@ TARGET_SOURCES := alarmdefinition.cpp \
 
 TARGET_SOURCES_TEST := test_main.cpp \
                        alarm.cpp \
-                       log.cpp \
-                       logger.cpp \
                        alarm_table_defs_test.cpp \
                        alarm_req_listener_test.cpp \
                        test_interposer.cpp \
@@ -138,7 +139,7 @@ COMMON_OBJECTS := custom_handler.o oid.o oidtree.o oid_inet_addr.o zmq_listener.
 cdiv_handler.so: cdivdata.o ${COMMON_OBJECTS}
 	g++ -o $@ $^ ${LDFLAGS} -fPIC -shared
 
-cw_alarm_agent: alarms_agent.o alarmdefinition.o alarm_table_defs.o alarm_model_table.o alarm_req_listener.o alarm_trap_sender.o itu_alarm_table.o json_alarms.o
+cw_alarm_agent: alarms_agent.o alarmdefinition.o alarm_table_defs.o alarm_model_table.o alarm_req_listener.o alarm_trap_sender.o itu_alarm_table.o json_alarms.o log.o logger.o snmp_agent.o
 	g++ -o $@ $^ ${LDFLAGS}
 
 memento_as_handler.so: mementoasdata.o ${COMMON_OBJECTS}

--- a/alarm_model_table.cpp
+++ b/alarm_model_table.cpp
@@ -40,6 +40,7 @@
  */
 
 #include "alarm_model_table.hpp"
+#include "log.h"
 
 static netsnmp_handler_registration* my_handler = NULL;
 static netsnmp_table_array_callbacks cb;
@@ -88,7 +89,7 @@ int initialize_table_alarmModelTable(void)
 
   if (my_handler)
   {
-    snmp_log(LOG_ERR, "initialize_table_alarmModelTable called again");
+    TRC_ERROR("initialize_table_alarmModelTable called again");
     return SNMP_ERR_NOERROR;
   }
 
@@ -105,7 +106,7 @@ int initialize_table_alarmModelTable(void)
             
   if (!my_handler || !table_info)
   {
-    snmp_log(LOG_ERR, "malloc failed: initialize_table_alarmModelTable");
+    TRC_ERROR("malloc failed: initialize_table_alarmModelTable");
     return SNMP_ERR_GENERR;
   }
 
@@ -234,7 +235,7 @@ int alarmModelTable_get_value(netsnmp_request_info* request,
     
     default: /** We shouldn't get here */
     {
-      snmp_log(LOG_ERR, "unknown column: alarmModelTable_get_value");
+      TRC_ERROR("unknown column: alarmModelTable_get_value");
       return SNMP_ERR_GENERR;
     }
   }
@@ -253,7 +254,7 @@ alarmModelTable_context* alarmModelTable_create_row_context(char* name,
   alarmModelTable_context* ctx = SNMP_MALLOC_TYPEDEF(alarmModelTable_context);
   if (!ctx)
   {
-    snmp_log(LOG_ERR, "malloc failed: alarmModelTable_create_row_context");
+    TRC_ERROR("malloc failed: alarmModelTable_create_row_context");
     return NULL;
   }
         
@@ -313,7 +314,7 @@ int alarmModelTable_index_to_oid(char* name,
   err = build_oid(&oid_idx->oids, &oid_idx->len, NULL, 0, &var_alarmListName);
   if (err)
   {
-    snmp_log(LOG_ERR, "error %d converting index to oid: alarmModelTable_index_to_oid", err);
+    TRC_ERROR("error %d converting index to oid: alarmModelTable_index_to_oid", err);
   }
 
   /*

--- a/alarm_table_defs.cpp
+++ b/alarm_table_defs.cpp
@@ -36,6 +36,7 @@
 #include <net-snmp/net-snmp-includes.h>
 #include <net-snmp/agent/net-snmp-agent-includes.h>
 
+#include "log.h"
 #include "alarm_table_defs.hpp"
 
 #include "rapidjson/document.h"
@@ -93,7 +94,7 @@ bool AlarmTableDefs::initialize(std::string& path)
   }
   else
   {
-    snmp_log(LOG_ERR, "Unable to open directory at %s", path.c_str());
+    TRC_ERROR("Unable to open directory at %s", path.c_str());
     rc = false;
   }
 
@@ -109,7 +110,7 @@ bool AlarmTableDefs::populate_map(std::string path,
 
   if (!rc)
   {
-    snmp_log(LOG_ERR, "%s", error.c_str());
+    TRC_ERROR("%s", error.c_str());
     return rc;
   }
 
@@ -118,7 +119,7 @@ bool AlarmTableDefs::populate_map(std::string path,
   {
     if (dup_check.count(a_it->_index))
     {
-      snmp_log(LOG_ERR, "alarm %d.*: is multiply defined", a_it->_index);
+      TRC_ERROR("alarm %d.*: is multiply defined", a_it->_index);
       rc = false;
       break;
     }

--- a/alarm_trap_sender.cpp
+++ b/alarm_trap_sender.cpp
@@ -38,6 +38,7 @@
 
 #include <stdexcept>
 
+#include "log.h"
 #include "alarm_trap_sender.hpp"
 #include "itu_alarm_table.hpp"
 
@@ -144,7 +145,7 @@ void AlarmTrapSender::issue_alarm(const std::string& issuer, const std::string& 
 
   if (sscanf(identifier.c_str(), "%u.%u", &index, &severity) != 2)
   {
-    snmp_log(LOG_ERR, "malformed alarm identifier: %s", identifier.c_str());
+    TRC_ERROR("malformed alarm identifier: %s", identifier.c_str());
     return;
   }
 
@@ -162,7 +163,7 @@ void AlarmTrapSender::issue_alarm(const std::string& issuer, const std::string& 
   }
   else
   {
-    snmp_log(LOG_ERR, "unknown alarm definition: %s", identifier.c_str());
+    TRC_ERROR("unknown alarm definition: %s", identifier.c_str());
   }
 }
 
@@ -218,6 +219,8 @@ void AlarmTrapSender::sync_alarms(bool do_clear)
 
 void AlarmTrapSender::send_trap(AlarmTableDef& alarm_table_def)
 {
+  TRC_WARNING("Trap with alarm ID %d.%d being sent", alarm_table_def.index(), alarm_table_def.state());
+
   static const oid snmp_trap_oid[] = {1,3,6,1,6,3,1,1,4,1,0};
   static const oid clear_oid[] = {1,3,6,1,2,1,118,0,3};
   static const oid active_oid[] = {1,3,6,1,2,1,118,0,2};

--- a/alarms_agent.cpp
+++ b/alarms_agent.cpp
@@ -39,6 +39,7 @@
 #include <signal.h>
 #include <string>
 #include <vector>
+#include <semaphore.h>
 
 #include "utils.h"
 #include "snmp_agent.h"

--- a/debian/clearwater-snmp-alarm-agent.init.d
+++ b/debian/clearwater-snmp-alarm-agent.init.d
@@ -89,6 +89,7 @@ get_settings()
 #
 do_start()
 {
+        get_settings
         mkdir -p $log_directory
 
         # Don't try and load MIBS at startup - we don't need them and this just causes lots of
@@ -107,7 +108,6 @@ do_start()
         ulimit -c unlimited
         # enable gdb to dump a parent process's stack
         echo 0 > /proc/sys/kernel/yama/ptrace_scope
-        get_settings
         DAEMON_ARGS="--snmp-ips $snmp_ip --community $snmp_community --log-dir $log_directory --log-level $log_level"
 
         start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON --chdir $HOME -- $DAEMON_ARGS \

--- a/debian/clearwater-snmp-alarm-agent.init.d
+++ b/debian/clearwater-snmp-alarm-agent.init.d
@@ -78,6 +78,8 @@ get_settings()
 {
         snmp_ip=0.0.0.0
         snmp_community=clearwater
+        log_directory=/var/log/clearwater-alarms/
+        log_level=4
         # Set up defaults and then pull in any overrides.
         . /etc/clearwater/config
 }
@@ -87,6 +89,8 @@ get_settings()
 #
 do_start()
 {
+        mkdir -p $log_directory
+        export MIBS=""
         # Return
         #   0 if daemon has been started
         #   1 if daemon was already running
@@ -101,7 +105,7 @@ do_start()
         # enable gdb to dump a parent process's stack
         echo 0 > /proc/sys/kernel/yama/ptrace_scope
         get_settings
-        DAEMON_ARGS="-i $snmp_ip -c $snmp_community"
+        DAEMON_ARGS="--snmp-ips $snmp_ip --community $snmp_community --log-dir $log_directory --log-level $log_level"
 
         start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON --chdir $HOME -- $DAEMON_ARGS \
                 || return 2

--- a/debian/clearwater-snmp-alarm-agent.init.d
+++ b/debian/clearwater-snmp-alarm-agent.init.d
@@ -90,6 +90,9 @@ get_settings()
 do_start()
 {
         mkdir -p $log_directory
+
+        # Don't try and load MIBS at startup - we don't need them and this just causes lots of
+        # "missing MIB" error logs.
         export MIBS=""
         # Return
         #   0 if daemon has been started


### PR DESCRIPTION
Part of the fix to https://github.com/Metaswitch/clearwater-snmp-handlers/issues/91.

This:

- logs to a file (/var/log/clearwater-alarms/clearwater-alarms_20151028T180000Z.txt) instead of syslog
- uses our (newish) standard SNMP setup code from cpp-common
- adds a log on each trap sent, for historical diagnostic purposes

I've tested that I get sensible logs out:

```
28-10-2015 18:39:43.361 UTC Warning alarm_trap_sender.cpp:222: Trap with alarm ID 1500.6 being sent
28-10-2015 18:39:55.017 UTC Warning alarm_trap_sender.cpp:222: Trap with alarm ID 1500.1 being sent
28-10-2015 18:40:53.825 UTC Warning alarm_trap_sender.cpp:222: Trap with alarm ID 1500.6 being sent
```

I will test that:
- alarms go out on the wire when snmp_ip is set
- alarms don't go out on the wire, and no errors are logged, when snmp_ip is unset or 0.0.0.0 - but the trap ID is still logged
- shutdown works OK (e.g. snmp_terminate doesn't hang)