### PR TITLE
[Reviewer: Andy] Ensure upstart actually starts the alarm agent

### DIFF
--- a/clearwater-snmp-alarm-agent.root/usr/share/clearwater/infrastructure/scripts/restart/clearwater_snmp_alarm_agent_restart
+++ b/clearwater-snmp-alarm-agent.root/usr/share/clearwater/infrastructure/scripts/restart/clearwater_snmp_alarm_agent_restart
@@ -34,4 +34,4 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-service clearwater-snmp-alarm-agent stop
+service clearwater-snmp-alarm-agent restart

--- a/debian/clearwater-snmp-alarm-agent.postinst
+++ b/debian/clearwater-snmp-alarm-agent.postinst
@@ -55,14 +55,6 @@ case "$1" in
     configure)
         # Ensure monit isn't monitoring us - this should be done by upstart
         rm -f /etc/monit/conf.d/alarm_agent.monit
-        # Force monit to reload its configuration
-        reload clearwater-monit || true
-
-        # Trigger an snmpd restart to load the sub-agent
-        service snmpd stop || true
-
-        # Restart the service
-        service clearwater-snmp-alarm-agent stop || true
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/rules
+++ b/debian/rules
@@ -26,8 +26,4 @@ override_dh_auto_test:
 override_dh_auto_install:
 	mkdir debian/tmp
 
-# Don't start - monit does that for us.
-override_dh_installinit:
-	dh_installinit --no-start -u"defaults 60 40"
-
 override_dh_shlibdeps:


### PR DESCRIPTION
Purge some monit infrastructure that wasn't included in https://github.com/Metaswitch/clearwater-snmp-handlers/pull/102.

Tested live - the alarm agent is now actually running after install.