### PR TITLE
[Reviewer: Ellie] Fixes for issue #96

### DIFF
--- a/alarm_req_listener.cpp
+++ b/alarm_req_listener.cpp
@@ -50,9 +50,15 @@
 
 AlarmReqListener AlarmReqListener::_instance;
 
-bool AlarmReqListener::start()
+bool AlarmReqListener::start(sem_t* term_sem)
 {
+  _term_sem = term_sem;
   if (!zmq_init_ctx())
+  {
+    return false;
+  }
+
+  if (!zmq_init_sck())
   {
     return false;
   }
@@ -94,8 +100,14 @@ void AlarmReqListener::stop()
 
 void* AlarmReqListener::listener_thread(void* alarm_req_listener)
 {
-  ((AlarmReqListener*) alarm_req_listener)->listener();
+  AlarmReqListener* l = (AlarmReqListener*)alarm_req_listener;
+  l->listener();
 
+  // If this thread exits, fire the termination semaphore to ensure the main thread shuts down.
+  if (l->_term_sem)
+  {
+    sem_post(l->_term_sem);
+  }
   return NULL;
 }
 
@@ -201,17 +213,9 @@ void AlarmReqListener::zmq_clean_sck()
 
 void AlarmReqListener::listener()
 {
-  bool sckOk = zmq_init_sck();
-
   pthread_mutex_lock(&_start_mutex);
   pthread_cond_signal(&_start_cond);
   pthread_mutex_unlock(&_start_mutex);
-
-  if (!sckOk)
-  {
-    return;
-  }
-
   while (1)
   {
     std::vector<std::string> msg;
@@ -237,6 +241,10 @@ void AlarmReqListener::listener()
     else if ((msg[0].compare("sync-alarms-no-clear") == 0) && (msg.size() == 1))
     {
       AlarmTrapSender::get_instance().sync_alarms(false);
+    }
+    else if ((msg[0].compare("poll") == 0) && (msg.size() == 1))
+    {
+      // do nothing, just reply "ok"
     }
     else
     {

--- a/alarm_req_listener.hpp
+++ b/alarm_req_listener.hpp
@@ -37,6 +37,7 @@
 
 #include <vector>
 #include <string>
+#include <semaphore.h>
  
 // Singleton which provides a listener thead to accept alarm requests from
 // clients via ZMQ, then generates alarmActiveState/alarmClearState inform
@@ -48,7 +49,7 @@ public:
   static AlarmReqListener& get_instance() {return _instance;}
 
   // Initialize ZMQ context and start listener thread.
-  bool start();
+  bool start(sem_t* term_sem);
 
   // Gracefully stop the listener thread and remove ZMQ context.
   void stop();
@@ -81,6 +82,8 @@ private:
 
   void* _ctx;
   void* _sck;
+
+  sem_t* _term_sem;
 };
 
 #endif

--- a/alarms_agent.cpp
+++ b/alarms_agent.cpp
@@ -95,7 +95,6 @@ int main (int argc, char **argv)
   int c;
   int optind;
 
-  printf("Helo world\n");
   opterr = 0;
   while ((c = getopt_long(argc, argv, "", long_opt, &optind)) != -1)
   {
@@ -139,7 +138,7 @@ int main (int argc, char **argv)
   AlarmTableDefs::get_instance().initialize(alarms_path);
 
   // Exit if the ReqListener wasn't able to fully start
-  if (!AlarmReqListener::get_instance().start())
+  if (!AlarmReqListener::get_instance().start(&term_sem))
   {
     TRC_ERROR("Hit error starting the listener - shutting down");
     return 0;

--- a/debian/clearwater-snmp-alarm-agent.postinst
+++ b/debian/clearwater-snmp-alarm-agent.postinst
@@ -53,6 +53,8 @@ set -e
 
 case "$1" in
     configure)
+        mkdir -p /var/run/clearwater
+
         # Ensure monit isn't monitoring us - this should be done by upstart
         rm -f /etc/monit/conf.d/alarm_agent.monit
         # Force monit to reload its configuration

--- a/debian/clearwater-snmp-alarm-agent.postinst
+++ b/debian/clearwater-snmp-alarm-agent.postinst
@@ -53,8 +53,6 @@ set -e
 
 case "$1" in
     configure)
-        mkdir -p /var/run/clearwater
-
         # Ensure monit isn't monitoring us - this should be done by upstart
         rm -f /etc/monit/conf.d/alarm_agent.monit
         # Force monit to reload its configuration

--- a/debian/clearwater-snmp-alarm-agent.upstart
+++ b/debian/clearwater-snmp-alarm-agent.upstart
@@ -29,6 +29,9 @@ script
     DAEMON_ARGS="--snmp-ips $snmp_ip --community $snmp_community --log-dir $log_directory --log-level $log_level"
   }
 
+  # /var/run/clearwater needs to exist so we can create a UNIX socket in it
+  mkdir -p /var/run/clearwater
+  
   get_daemon_args
   /usr/share/clearwater/bin/cw_alarm_agent $DAEMON_ARGS
 end script

--- a/ut/alarm_req_listener_test.cpp
+++ b/ut/alarm_req_listener_test.cpp
@@ -78,7 +78,7 @@ public:
 
     cwtest_intercept_netsnmp(&_ms);
 
-    AlarmReqListener::get_instance().start();
+    AlarmReqListener::get_instance().start(NULL);
     AlarmReqAgent::get_instance().start();
   }
 
@@ -451,7 +451,7 @@ TEST_F(AlarmReqListenerZmqErrorTest, CreateContext)
 {
   EXPECT_CALL(_mz, zmq_ctx_new()).WillOnce(ReturnNull());
 
-  EXPECT_FALSE(AlarmReqListener::get_instance().start());
+  EXPECT_FALSE(AlarmReqListener::get_instance().start(NULL));
   EXPECT_TRUE(_log.contains("zmq_ctx_new failed:"));
 }
 
@@ -459,11 +459,8 @@ TEST_F(AlarmReqListenerZmqErrorTest, CreateSocket)
 {
   EXPECT_CALL(_mz, zmq_ctx_new()).WillOnce(Return(&_c));
   EXPECT_CALL(_mz, zmq_socket(_,_)) .WillOnce(ReturnNull());
-  EXPECT_CALL(_mz, zmq_ctx_destroy(_)).WillOnce(Return(0));
 
-  EXPECT_TRUE(AlarmReqListener::get_instance().start());
-
-  AlarmReqListener::get_instance().stop();
+  EXPECT_FALSE(AlarmReqListener::get_instance().start(NULL));
 
   EXPECT_TRUE(_log.contains("zmq_socket failed:"));
 }
@@ -474,11 +471,8 @@ TEST_F(AlarmReqListenerZmqErrorTest, BindSocket)
   EXPECT_CALL(_mz, zmq_socket(_,_)).WillOnce(Return(&_s));
   EXPECT_CALL(_mz, zmq_setsockopt(_,_,_,_)).WillOnce(Return(0));
   EXPECT_CALL(_mz, zmq_bind(_,_)).WillOnce(Return(-1));
-  EXPECT_CALL(_mz, zmq_ctx_destroy(_)).WillOnce(Return(0));
 
-  EXPECT_TRUE(AlarmReqListener::get_instance().start());
-
-  AlarmReqListener::get_instance().stop();
+  EXPECT_FALSE(AlarmReqListener::get_instance().start(NULL));
 
   EXPECT_TRUE(_log.contains("zmq_bind failed:"));
 }
@@ -494,7 +488,7 @@ TEST_F(AlarmReqListenerZmqErrorTest, MsgReceive)
   EXPECT_CALL(_mz, zmq_close(_)).WillOnce(Return(0));
   EXPECT_CALL(_mz, zmq_ctx_destroy(_)).WillOnce(Return(0));
 
-  EXPECT_TRUE(AlarmReqListener::get_instance().start());
+  EXPECT_TRUE(AlarmReqListener::get_instance().start(NULL));
 
   _mz.call_complete(ZmqInterface::ZMQ_CLOSE, 5);
 
@@ -515,7 +509,7 @@ TEST_F(AlarmReqListenerZmqErrorTest, GetSockOpt)
   EXPECT_CALL(_mz, zmq_close(_)).WillOnce(Return(0));
   EXPECT_CALL(_mz, zmq_ctx_destroy(_)).WillOnce(Return(0));
 
-  EXPECT_TRUE(AlarmReqListener::get_instance().start());
+  EXPECT_TRUE(AlarmReqListener::get_instance().start(NULL));
 
   _mz.call_complete(ZmqInterface::ZMQ_CLOSE, 5);
 
@@ -537,7 +531,7 @@ TEST_F(AlarmReqListenerZmqErrorTest, MsgClose)
   EXPECT_CALL(_mz, zmq_close(_)).WillOnce(Return(0));
   EXPECT_CALL(_mz, zmq_ctx_destroy(_)).WillOnce(Return(0));
 
-  EXPECT_TRUE(AlarmReqListener::get_instance().start());
+  EXPECT_TRUE(AlarmReqListener::get_instance().start(NULL));
 
   _mz.call_complete(ZmqInterface::ZMQ_CLOSE, 5);
 
@@ -565,7 +559,7 @@ TEST_F(AlarmReqListenerZmqErrorTest, Send)
   EXPECT_CALL(_mz, zmq_close(_)).WillOnce(Return(0));
   EXPECT_CALL(_mz, zmq_ctx_destroy(_)).WillOnce(Return(0));
 
-  EXPECT_TRUE(AlarmReqListener::get_instance().start());
+  EXPECT_TRUE(AlarmReqListener::get_instance().start(NULL));
 
   _mz.call_complete(ZmqInterface::ZMQ_CLOSE, 5);
 
@@ -585,7 +579,7 @@ TEST_F(AlarmReqListenerZmqErrorTest, CloseSocket)
   EXPECT_CALL(_mz, zmq_close(_)).WillOnce(Return(-1));
   EXPECT_CALL(_mz, zmq_ctx_destroy(_)).WillOnce(Return(0));
 
-  EXPECT_TRUE(AlarmReqListener::get_instance().start());
+  EXPECT_TRUE(AlarmReqListener::get_instance().start(NULL));
 
   _mz.call_complete(ZmqInterface::ZMQ_CLOSE, 5);
 
@@ -604,7 +598,7 @@ TEST_F(AlarmReqListenerZmqErrorTest, DestroyContext)
   EXPECT_CALL(_mz, zmq_close(_)).WillOnce(Return(0));
   EXPECT_CALL(_mz, zmq_ctx_destroy(_)).WillOnce(Return(-1));
 
-  EXPECT_TRUE(AlarmReqListener::get_instance().start());
+  EXPECT_TRUE(AlarmReqListener::get_instance().start(NULL));
 
   _mz.call_complete(ZmqInterface::ZMQ_CLOSE, 5);
 


### PR DESCRIPTION
- create the /var/run/clearwater directory
- catch zmq_bind failures before starting the listener thread
- fire the termination semaphore when the listener thread exits

This doesn't fully implement Monit polling of the alarm agent, but does add a 'poll' message to the list of ZMQ messages we'll accept.