### PR TITLE
[Reviewer: Rob] Tests in clearwater-fvtest and clearwater-snmp-handlers ...

### DIFF
--- a/fvtest.conf
+++ b/fvtest.conf
@@ -1,4 +1,4 @@
-agentAddress udp:16161,udp6:[::]:16161
+agentAddress udp:16162,udp6:[::]:16162
 rocommunity clearwater
 
 view clearwater included .1

--- a/ut/alarm_tables_testing.hpp
+++ b/ut/alarm_tables_testing.hpp
@@ -6,6 +6,8 @@
 class CustomDefs: public SNMPTest
 {
 public:
+  CustomDefs() {alarm_address = "16162";}
+  
   AlarmTableDef* def_cleared;
   AlarmTableDef* def_raised;
   AlarmTableDef* def1_cleared;

--- a/ut/alarm_tables_testing.hpp
+++ b/ut/alarm_tables_testing.hpp
@@ -112,7 +112,6 @@ void CustomDefs::TearDown()
 std::string get_index_from_row(std::string snmpwalk_row)
 {
   std::vector<std::string> index_fields;
-  printf("snmpwalk_row output: %s /n", snmpwalk_row.c_str());
   // This splits up each part of the index field for an alarm. The alarm's
   // index is the last element of the index field.
   // For example snmpwalk_row =

--- a/ut/alarm_tables_testing.hpp
+++ b/ut/alarm_tables_testing.hpp
@@ -6,8 +6,7 @@
 class CustomDefs: public SNMPTest
 {
 public:
-  CustomDefs() {alarm_address = "16162";}
-  
+  CustomDefs() : SNMPTest("16162") { }
   AlarmTableDef* def_cleared;
   AlarmTableDef* def_raised;
   AlarmTableDef* def1_cleared;


### PR DESCRIPTION
now use different alarm agents.
This fixes issue116:
https://github.com/Metaswitch/clearwater-snmp-handlers/issues/116