### PR TITLE
[Reviewer: Andy] Add a trigger to restart the alarm agent

### DIFF
--- a/debian/clearwater-snmp-alarm-agent.postinst
+++ b/debian/clearwater-snmp-alarm-agent.postinst
@@ -63,7 +63,7 @@ case "$1" in
     triggered)
         # Restart the alarm agent. Use restart rather than stop
         # as the alarm agent is covered by upstart not monit
-        service clearwater-snmp-alarm-agent restart || /bin/true
+        restart clearwater-snmp-alarm-agent || /bin/true
     ;;
 
     *)

--- a/debian/clearwater-snmp-alarm-agent.postinst
+++ b/debian/clearwater-snmp-alarm-agent.postinst
@@ -60,6 +60,12 @@ case "$1" in
     abort-upgrade|abort-remove|abort-deconfigure)
     ;;
 
+    triggered)
+        # Restart the alarm agent. Use restart rather than stop
+        # as the alarm agent is covered by upstart not monit
+        service clearwater-snmp-alarm-agent restart || /bin/true
+    ;;
+
     *)
         echo "postinst called with unknown argument \`$1'" >&2
         exit 1
@@ -72,4 +78,3 @@ esac
 #DEBHELPER#
 
 exit 0
-

--- a/debian/clearwater-snmp-alarm-agent.triggers
+++ b/debian/clearwater-snmp-alarm-agent.triggers
@@ -1,0 +1,1 @@
+interest clearwater-snmp-alarm-agent


### PR DESCRIPTION
Andy, can you review this change to add a trigger to the alarm agent to restart it? This PR adds the restart function, and makes the clearwater-snmp-alarm-agent interested in the alarm agent trigger