### PR TITLE
[Reviewer: Rob] Remove clear all alarms

### DIFF
--- a/alarm_trap_sender.cpp
+++ b/alarm_trap_sender.cpp
@@ -205,10 +205,7 @@ void AlarmTrapSender::sync_alarms(bool do_clear)
 
   for (ObservedAlarmsIterator it = _observed_alarms.begin(); it != _observed_alarms.end(); it++)
   {
-    if (it->alarm_table_def().severity() != AlarmDef::CLEARED)
-    {
-      send_trap(it->alarm_table_def());
-    }
+    send_trap(it->alarm_table_def());
   }
 }
 

--- a/ut/alarm_req_listener_test.cpp
+++ b/ut/alarm_req_listener_test.cpp
@@ -310,36 +310,6 @@ TEST_F(AlarmReqListenerTest, SetAlarmRepeatedState)
   _ms.trap_complete(2, 5);
 }
 
-TEST_F(AlarmReqListenerTest, ClearAlarms)
-{
-  advance_time_ms(AlarmFilter::ALARM_FILTER_TIME + 1);
-
-  {
-    InSequence s;
-
-    EXPECT_CALL(_ms, send_v2trap(_)).
-      Times(3);
-
-    EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
-                                          1000)));
-
-    EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
-                                          1001)));
-
-    EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
-                                          1002)));
-  }
-
-  _alarm_1.set();
-  _alarm_2.set();
-  _alarm_3.set();
-
-  AlarmState::clear_all(issuer1);
-  AlarmState::clear_all(issuer2);
-
-  _ms.trap_complete(6, 5);
-}
-
 TEST_F(AlarmReqListenerTest, SyncAlarms)
 {
   advance_time_ms(AlarmFilter::ALARM_FILTER_TIME + 1);


### PR DESCRIPTION
As we discussed, the trap sender now sends all alarms it knows about, set or cleared. 

As there is no longer a clear_all method for alarms, I am removing the UT for it.