### PR TITLE
[No Reviewer] Remove clear_alarms

### DIFF
--- a/alarm_req_listener.cpp
+++ b/alarm_req_listener.cpp
@@ -236,10 +236,6 @@ void AlarmReqListener::listener()
     {
       AlarmTrapSender::get_instance().issue_alarm(msg[1], msg[2]);
     }
-    else if ((msg[0].compare("clear-alarms") == 0) && (msg.size() == 2))
-    {
-      AlarmTrapSender::get_instance().clear_alarms(msg[1]);
-    }
     else if ((msg[0].compare("sync-alarms") == 0) && (msg.size() == 1))
     {
       AlarmTrapSender::get_instance().sync_alarms(true);

--- a/alarm_trap_sender.cpp
+++ b/alarm_trap_sender.cpp
@@ -161,33 +161,6 @@ void AlarmTrapSender::issue_alarm(const std::string& issuer, const std::string& 
   }
 }
 
-void AlarmTrapSender::clear_alarms(const std::string& issuer)
-{
-  AlarmTableDefs& defs = AlarmTableDefs::get_instance();
-
-  ObservedAlarmsIterator it = _observed_alarms.begin();
-  while (it != _observed_alarms.end())
-  {
-    if (it->issuer() == issuer)
-    {
-      if (it->alarm_table_def().severity() != AlarmDef::CLEARED)
-      {
-        // For each alarm that is currently raised in a non-CLEARED raised
-        // state, we generate the corresponding CLEARED definition of that
-        // alarm. 
-        AlarmTableDef& clear_def = defs.get_definition(it->alarm_table_def().alarm_index(), AlarmDef::CLEARED);
-      
-       if (!AlarmFilter::get_instance().alarm_filtered(clear_def.alarm_index(), clear_def.severity()))
-        {
-          send_trap(clear_def);
-          _observed_alarms.update(clear_def, issuer);
-        }
-      }
-    }
-    ++it;
-  }
-}
-
 void AlarmTrapSender::sync_alarms(bool do_clear)
 {
   AlarmTableDefs& defs = AlarmTableDefs::get_instance();

--- a/alarm_trap_sender.hpp
+++ b/alarm_trap_sender.hpp
@@ -157,10 +157,6 @@ public:
   // to filtering).
   void issue_alarm(const std::string& issuer, const std::string& identifier);
 
-  // Generates alarmClearState informs corresponding to each of the active 
-  // alarms previously initiated by issuer. 
-  void clear_alarms(const std::string& issuer);
-
   // Optionally generates alarmClearState informs corresponding to each of
   // the alarms defined for this node; followed by alarmActiveState informs
   // for each currently active alarm.


### PR DESCRIPTION
The clear_alarms functionality is no longer going to be used. 
The calls to `clear_all` have been removed already from all modules, and the function will be removed from cpp_common Alarms class shortly.

Removing it from snmp-handlers. This will fix the coverage failure.