### PR TITLE
Reviewer Rob - Use SNMP NOTIFY callbacks to re-send unacknowledged alarms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,12 @@ include build-infra/cpp.mk
 # As a special case, running the agent test needs /var/run/clearwater to exist on the local machine
 run_cw_alarm_test : | /var/run/clearwater
 run_cw_alarm_fvtest : | /var/run/clearwater
+debug_cw_alarm_test : | /var/run/clearwater
+debug_cw_alarm_fvtest : | /var/run/clearwater
+valgrind_cw_alarm_test : | /var/run/clearwater
+valgrind_cw_alarm_fvtest : | /var/run/clearwater
+valgrind_check_cw_alarm_test : | /var/run/clearwater
+valgrind_check_cw_alarm_fvtest : | /var/run/clearwater
 /var/run/clearwater :
 	sudo mkdir -p $@
 	sudo chmod -R o+wr /var/run/clearwater

--- a/alarm_table_defs.cpp
+++ b/alarm_table_defs.cpp
@@ -56,7 +56,7 @@ AlarmTableDefs AlarmTableDefs::_instance;
 // Translate ituAlarmPerceivedSeverity to alarmModelState based upon mapping
 // defined in section 5.4 of RFC 3877.
 // https://tools.ietf.org/html/rfc3877#section-5.4
-unsigned int AlarmTableDef::state()
+unsigned int AlarmTableDef::state() const
 {
   static const unsigned int severity_to_state[] = {2, 1, 2, 6, 5, 4, 3};
   unsigned int idx = severity();

--- a/alarm_table_defs.hpp
+++ b/alarm_table_defs.hpp
@@ -60,25 +60,25 @@ public:
     _alarm_definition(alarm_definition),
     _severity_details(severity_details) {}
 
-  unsigned int state();
+  unsigned int state() const;
 
-  unsigned int alarm_index()    {return _alarm_definition._index;} 
-  AlarmDef::Cause cause() {return _alarm_definition._cause;}
+  unsigned int alarm_index() const   {return _alarm_definition._index;} 
+  AlarmDef::Cause cause() const      {return _alarm_definition._cause;}
 
-  AlarmDef::Severity severity()    {return _severity_details._severity;}
-  const std::string& description() {return _severity_details._description;}
-  const std::string& details()     {return _severity_details._details;}
+  AlarmDef::Severity severity() const    {return _severity_details._severity;}
+  const std::string& description() const {return _severity_details._description;}
+  const std::string& details() const     {return _severity_details._details;}
 
   // LCOV_EXCL_START
-  bool is_valid() {return _valid;}
-  bool is_not_clear() {return severity() != AlarmDef::CLEARED;}
+  bool is_valid() const     {return _valid;}
+  bool is_not_clear() const {return severity() != AlarmDef::CLEARED;}
   // LCOV_EXCL_STOP
 
 private:
   bool _valid;
 
-  const AlarmDef::AlarmDefinition _alarm_definition;
-  const AlarmDef::SeverityDetails _severity_details;
+  AlarmDef::AlarmDefinition _alarm_definition;
+  AlarmDef::SeverityDetails _severity_details;
 };
 
 // Unique key for alarm table definitions is comprised of alarm index and

--- a/alarm_trap_sender.cpp
+++ b/alarm_trap_sender.cpp
@@ -70,9 +70,16 @@ bool ObservedAlarms::is_active(const AlarmTableDef& alarm_table_def)
     // Either the current alarm doesn't exist in the ObservedAlarms mapping
     // or there is an entry for the current alarm in the mapping but at a
     // different severity to the one we are currently raising the alarm with.
-    TRC_DEBUG("Alarm is active at %d severity which does not match the given severity (%d)",
-              it->second.alarm_table_def().severity(),
-              alarm_table_def.severity());
+    if (it == _index_to_entry.end())
+    {
+      TRC_DEBUG("Alarm was not known at any severity");
+    }
+    else
+    {
+      TRC_DEBUG("Alarm is active at %d severity which does not match the given severity (%d)",
+                it->second.alarm_table_def().severity(),
+                alarm_table_def.severity());
+    }
     return false;
   }
   else
@@ -146,7 +153,6 @@ unsigned long AlarmFilter::current_time_ms()
 
 void AlarmTrapSender::issue_alarm(const std::string& issuer, const std::string& identifier)
 {
-  
   unsigned int index;
   unsigned int severity;
   if (sscanf(identifier.c_str(), "%u.%u", &index, &severity) != 2)
@@ -214,7 +220,7 @@ void AlarmTrapSender::alarm_trap_send_callback(int op,
     // with the current architecture.  For now, if this OP occurs, we'll treat
     // it as a successful send.
     // LCOV_EXCL_START - Unhittable
-    TRC_DEBUG("Ignoring failed alarm send to peer %s", peer.c_str());
+    TRC_WARNING("Ignoring failed alarm send to peer %s", peer.c_str());
     break;
     // LCOV_EXCL_STOP
   case NETSNMP_CALLBACK_OP_TIMED_OUT:

--- a/alarm_trap_sender.hpp
+++ b/alarm_trap_sender.hpp
@@ -167,8 +167,11 @@ public:
   // or not).
   //
   // @param op - NETSNMP operation code
+  // @param peer - The SNMP peer that failed
   // @param alarm_table_def - The alarm entry that was being raised
-  void alarm_trap_send_callback(int op, const AlarmTableDef& alarm_table_def);
+  void alarm_trap_send_callback(int op,
+                                const std::string& peer,
+                                const AlarmTableDef& alarm_table_def);
 
   static AlarmTrapSender& get_instance() {return _instance;}
 private:

--- a/alarm_trap_sender.hpp
+++ b/alarm_trap_sender.hpp
@@ -48,16 +48,16 @@
 class AlarmListEntry
 {
 public:
-  AlarmListEntry() : _alarm_table_def(NULL) {}
+  AlarmListEntry() {}
 
-  AlarmListEntry(AlarmTableDef& alarm_table_def, const std::string& issuer) :
-    _alarm_table_def(&alarm_table_def), _issuer(issuer) {}
+  AlarmListEntry(const AlarmTableDef& alarm_table_def, const std::string& issuer) :
+    _alarm_table_def(alarm_table_def), _issuer(issuer) {}
 
-  AlarmTableDef& alarm_table_def() {return *_alarm_table_def;}
+  const AlarmTableDef& alarm_table_def() {return _alarm_table_def;}
   std::string& issuer() {return _issuer;}
 
 private:
-  AlarmTableDef* _alarm_table_def;
+  AlarmTableDef _alarm_table_def;
   std::string _issuer;
 };
 
@@ -87,7 +87,8 @@ public:
   // Adds any alarm to the mapping if it does not already exist and returns 
   // true. If an entry does exist but at a different severity then we 
   // update the mapping and return true.
-  bool update(AlarmTableDef& alarm_table_def, const std::string& issuer);
+  bool update(const AlarmTableDef& alarm_table_def, const std::string& issuer);
+  bool is_active(const AlarmTableDef& alarm_table_def);
 
   ObservedAlarmsIterator begin() {return _index_to_entry.begin();}
   ObservedAlarmsIterator end() {return _index_to_entry.end();}
@@ -162,11 +163,18 @@ public:
   // alarm.
   void sync_alarms();
 
+  // Callback triggered when an alarm send completes (either successfully
+  // or not).
+  //
+  // @param op - NETSNMP operation code
+  // @param alarm_table_def - The alarm entry that was being raised
+  void alarm_trap_send_callback(int op, const AlarmTableDef& alarm_table_def);
+
   static AlarmTrapSender& get_instance() {return _instance;}
 private:
   AlarmTrapSender() {}
 
-  void send_trap(AlarmTableDef& alarm_table_def);
+  void send_trap(const AlarmTableDef& alarm_table_def);
 
   ObservedAlarms _observed_alarms;
 

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Priority: optional
 # clearwater-infrastructure explicitly checks for packages of this name when
 # updating
 Maintainer: Project Clearwater Maintainers <maintainers@projectclearwater.org>
-Build-Depends: debhelper (>= 8.0.0), build-essential, libsnmp-dev, libboost-dev, libzmq3-dev
+Build-Depends: debhelper (>= 8.0.0), build-essential, libsnmp-dev (= 5.7.2~dfsg-clearwater3), libboost-dev, libzmq3-dev
 Standards-Version: 3.9.2
 Homepage: http://projectclearwater.org/
 

--- a/ut/alarm_req_listener_test.cpp
+++ b/ut/alarm_req_listener_test.cpp
@@ -54,6 +54,7 @@
 #include "test_interposer.hpp"
 
 using ::testing::_;
+using ::testing::A;
 using ::testing::Return;
 using ::testing::ReturnNull;
 using ::testing::InSequence;
@@ -61,123 +62,11 @@ using ::testing::MakeMatcher;
 using ::testing::Matcher;
 using ::testing::MatcherInterface;
 using ::testing::MatchResultListener;
+using ::testing::SaveArg;
+using ::testing::Invoke;
 
 static const char issuer1[] = "sprout";
 static const char issuer2[] = "homestead";
-
-class AlarmReqListenerTest : public ::testing::Test
-{
-public:
-  AlarmReqListenerTest() :
-    _alarm_1(issuer1, 1000, AlarmDef::CRITICAL),
-    _alarm_2(issuer1, 1001, AlarmDef::CRITICAL),
-    _alarm_3(issuer2, 1002, AlarmDef::CRITICAL)
-  {
-    cwtest_completely_control_time();
-    cwtest_advance_time_ms(_delta_ms);
-
-    cwtest_intercept_netsnmp(&_ms);
-
-    AlarmReqListener::get_instance().start(NULL);
-    AlarmReqAgent::get_instance().start();
-  }
-
-  virtual ~AlarmReqListenerTest()
-  {
-    AlarmReqAgent::get_instance().stop();
-    AlarmReqListener::get_instance().stop();
-
-    cwtest_restore_netsnmp();
-    cwtest_reset_time();
-  }
-
-  static void SetUpTestCase()
-  {
-    AlarmTableDefs::get_instance().initialize(std::string(UT_DIR).append("/valid_alarms/"));
-  }
-
-  void sync_alarms()
-  {
-    std::vector<std::string> req;
-
-    req.push_back("sync-alarms");
-
-    AlarmReqAgent::get_instance().alarm_request(req);
-  }
-
-  void issue_malformed_alarm()
-  {
-    std::vector<std::string> req;
-
-    req.push_back("issue-alarm");
-    req.push_back("sprout");
-    req.push_back("one.two");
-
-    AlarmReqAgent::get_instance().alarm_request(req);
-  }
-
-  void issue_unknown_alarm()
-  {
-    std::vector<std::string> req;
-
-    req.push_back("issue-alarm");
-    req.push_back("sprout");
-    req.push_back("0000.0");
-
-    AlarmReqAgent::get_instance().alarm_request(req);
-  }
-
-  void invalid_zmq_request()
-  {
-    std::vector<std::string> req;
-
-    req.push_back("invalid-request");
-
-    AlarmReqAgent::get_instance().alarm_request(req);
-  }
-
-  void advance_time_ms(long delta_ms)
-  {
-    _delta_ms += delta_ms;
-
-    cwtest_advance_time_ms(delta_ms);
-  }
-
-private:
-  MockNetSnmpInterface _ms;
-  CapturingTestLogger _log;
-  Alarm _alarm_1;
-  Alarm _alarm_2;
-  Alarm _alarm_3;
-  static long _delta_ms;
-};
-
-long AlarmReqListenerTest::_delta_ms = 0;
-
-class AlarmReqListenerZmqErrorTest : public ::testing::Test
-{
-public:
-  AlarmReqListenerZmqErrorTest() :
-    _c(1),
-    _s(2)
-  {
-    cwtest_intercept_netsnmp(&_ms);
-    cwtest_intercept_zmq(&_mz);
-  }
-
-  virtual ~AlarmReqListenerZmqErrorTest()
-  {
-    cwtest_restore_zmq();
-    cwtest_restore_netsnmp();
-  }
-
-private:
-  MockNetSnmpInterface _ms;
-  CapturingTestLogger _log;
-  MockZmqInterface _mz;
-  int _c;
-  int _s;
-};
 
 class TrapVarsMatcher : public MatcherInterface<netsnmp_variable_list*> {
 public:
@@ -235,6 +124,156 @@ public:
   unsigned int _alarm_index;
 };
 
+class SNMPCallbackCollector
+{
+public:
+  void call_all_callbacks()
+  {
+    for (auto ii = _callbacks.begin();
+         ii != _callbacks.end();
+         ++ii)
+    {
+      ii->first(NETSNMP_CALLBACK_OP_RECEIVED_MESSAGE, NULL, 0, NULL, ii->second);
+    }
+    _callbacks.clear();
+  }
+
+  void collect_callback(netsnmp_variable_list* ignored, snmp_callback callback, void* correlator)
+  {
+    _callbacks.emplace_back(callback, correlator);
+  }
+
+private:
+  std::vector<std::pair<snmp_callback, void*>> _callbacks;
+};
+
+class AlarmReqListenerTest : public ::testing::Test
+{
+public:
+  AlarmReqListenerTest() :
+    _alarm_1(issuer1, 1000, AlarmDef::CRITICAL),
+    _alarm_2(issuer1, 1001, AlarmDef::CRITICAL),
+    _alarm_3(issuer2, 1002, AlarmDef::CRITICAL)
+  {
+    cwtest_completely_control_time();
+    cwtest_advance_time_ms(_delta_ms);
+
+    cwtest_intercept_netsnmp(&_ms);
+
+    AlarmReqListener::get_instance().start(NULL);
+    AlarmReqAgent::get_instance().start();
+  }
+
+  virtual ~AlarmReqListenerTest()
+  {
+    AlarmReqAgent::get_instance().stop();
+    AlarmReqListener::get_instance().stop();
+
+    cwtest_restore_netsnmp();
+    cwtest_reset_time();
+  }
+
+  static void SetUpTestCase()
+  {
+    AlarmTableDefs::get_instance().initialize(std::string(UT_DIR).append("/valid_alarms/"));
+  }
+
+  void TearDown()
+  {
+    _collector.call_all_callbacks();
+  }
+
+  void sync_alarms()
+  {
+    std::vector<std::string> req;
+
+    req.push_back("sync-alarms");
+
+    AlarmReqAgent::get_instance().alarm_request(req);
+  }
+
+  void issue_malformed_alarm()
+  {
+    std::vector<std::string> req;
+
+    req.push_back("issue-alarm");
+    req.push_back("sprout");
+    req.push_back("one.two");
+
+    AlarmReqAgent::get_instance().alarm_request(req);
+  }
+
+  void issue_unknown_alarm()
+  {
+    std::vector<std::string> req;
+
+    req.push_back("issue-alarm");
+    req.push_back("sprout");
+    req.push_back("0000.0");
+
+    AlarmReqAgent::get_instance().alarm_request(req);
+  }
+
+  void invalid_zmq_request()
+  {
+    std::vector<std::string> req;
+
+    req.push_back("invalid-request");
+
+    AlarmReqAgent::get_instance().alarm_request(req);
+  }
+
+  void advance_time_ms(long delta_ms)
+  {
+    _delta_ms += delta_ms;
+
+    cwtest_advance_time_ms(delta_ms);
+  }
+
+private:
+  MockNetSnmpInterface _ms;
+  CapturingTestLogger _log;
+  SNMPCallbackCollector _collector;
+  Alarm _alarm_1;
+  Alarm _alarm_2;
+  Alarm _alarm_3;
+  static long _delta_ms;
+};
+
+long AlarmReqListenerTest::_delta_ms = 0;
+
+class AlarmReqListenerZmqErrorTest : public ::testing::Test
+{
+public:
+  AlarmReqListenerZmqErrorTest() :
+    _c(1),
+    _s(2)
+  {
+    cwtest_intercept_netsnmp(&_ms);
+    cwtest_intercept_zmq(&_mz);
+  }
+
+  virtual ~AlarmReqListenerZmqErrorTest()
+  {
+    cwtest_restore_zmq();
+    cwtest_restore_netsnmp();
+  }
+
+private:
+  MockNetSnmpInterface _ms;
+  CapturingTestLogger _log;
+  MockZmqInterface _mz;
+  int _c;
+  int _s;
+};
+
+// Safely set up an expect call for an SNMP trap send that will succeed.
+#define COLLECT_CALL(CALL) EXPECT_CALL(_ms, CALL).                                \
+  WillOnce(Invoke(&_collector, &SNMPCallbackCollector::collect_callback))
+#define COLLECT_CALLS(N, CALL) EXPECT_CALL(_ms, CALL).                            \
+  Times(N).                                                                       \
+  WillRepeatedly(Invoke(&_collector, &SNMPCallbackCollector::collect_callback))
+
 inline Matcher<netsnmp_variable_list*> TrapVars(TrapVarsMatcher::TrapType trap_type,
                                                 unsigned int alarm_index) {
   return MakeMatcher(new TrapVarsMatcher(trap_type, alarm_index));
@@ -242,39 +281,34 @@ inline Matcher<netsnmp_variable_list*> TrapVars(TrapVarsMatcher::TrapType trap_t
 
 TEST_F(AlarmReqListenerTest, ClearAlarmNoSet)
 {
-  EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
-                                        1000)));
+  COLLECT_CALL(send_v2trap(TrapVars(TrapVarsMatcher::CLEAR, 1000), _, _));
 
-  _alarm_1._clear_state.issue();
+  _alarm_1.clear();
   _ms.trap_complete(1, 5);
 }
 
 TEST_F(AlarmReqListenerTest, SetAlarm)
 {
-  EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::ACTIVE,
-                                        1000)));
+  COLLECT_CALL(send_v2trap(TrapVars(TrapVarsMatcher::ACTIVE, 1000), _, _));
 
   _alarm_1.set();
   _ms.trap_complete(1, 5);
 }
 
 // The class responsible for generating alarm inform notifications
-// (AlarmTrapSender) is a singleton and hence we have to use the same instance 
-// for each test. As such when we set an alarm in the previous test, it still exists 
-// within ObservedAlarms mapping for the next test and hence we have to expect 
-// that alarm be filtered out. We also have to advance time here so that our alarms 
-// are not filtered out by the alarm_filtered function with the alarm trap sender. 
-// This filters out any alarms raised in a repeated state during five seconds of 
-// each other (the value of ALARM_FILTER_TIME), even if the state of the alarm 
+// (AlarmTrapSender) is a singleton and hence we have to use the same instance
+// for each test. As such when we set an alarm in the previous test, it still exists
+// within ObservedAlarms mapping for the next test and hence we have to expect
+// that alarm be filtered out. We also have to advance time here so that our alarms
+// are not filtered out by the alarm_filtered function with the alarm trap sender.
+// This filters out any alarms raised in a repeated state during five seconds of
+// each other (the value of ALARM_FILTER_TIME), even if the state of the alarm
 // changes with that five seconds.
 TEST_F(AlarmReqListenerTest, ClearAlarm)
 {
   advance_time_ms(AlarmFilter::ALARM_FILTER_TIME + 1);
-  EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
-                                        1000)));
-
+  COLLECT_CALL(send_v2trap(TrapVars(TrapVarsMatcher::CLEAR, 1000), _, _));
   _alarm_1.set();
-
   _alarm_1.clear();
   _ms.trap_complete(1, 5);
 }
@@ -286,13 +320,11 @@ TEST_F(AlarmReqListenerTest, ClearAlarm)
 TEST_F(AlarmReqListenerTest, SetAlarmRepeatedState)
 {
   advance_time_ms(AlarmFilter::ALARM_FILTER_TIME + 1);
-  
+
   {
     InSequence s;
-    EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::ACTIVE,
-                                          1000)));
-    EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
-                                          1000)));
+    COLLECT_CALL(send_v2trap(TrapVars(TrapVarsMatcher::ACTIVE, 1000), _, _));
+    COLLECT_CALL(send_v2trap(TrapVars(TrapVarsMatcher::CLEAR, 1000), _, _));
   }
   _alarm_1.set();
   advance_time_ms(30);
@@ -304,39 +336,38 @@ TEST_F(AlarmReqListenerTest, SetAlarmRepeatedState)
 TEST_F(AlarmReqListenerTest, SyncAlarms)
 {
   advance_time_ms(AlarmFilter::ALARM_FILTER_TIME + 1);
-  
+
   // Put our three alarms into a state we expect
   {
     InSequence s;
 
-    EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::ACTIVE,
-                                          1000)));
+    COLLECT_CALL(send_v2trap(TrapVars(TrapVarsMatcher::ACTIVE,
+                                          1000), _, _));
 
-    EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
-                                          1001)));
+    COLLECT_CALL(send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
+                                          1001), _, _));
 
-    EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
-                                          1002))); 
+    COLLECT_CALL(send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
+                                          1002), _, _));
   }
-  
+
   _alarm_1.set();
   _alarm_2.clear();
   _alarm_3.clear();
-  
+
   _ms.trap_complete(3, 5);
 
   // Now call sync_alarms and expect those states to be retransmitted
   {
     InSequence s;
+    COLLECT_CALL(send_v2trap(TrapVars(TrapVarsMatcher::ACTIVE,
+                                          1000), _, _));
 
-    EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::ACTIVE,
-                                          1000)));
+    COLLECT_CALL(send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
+                                          1001), _, _));
 
-    EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
-                                          1001)));
-
-    EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
-                                          1002))); 
+    COLLECT_CALL(send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
+                                          1002), _, _));
   }
 
   sync_alarms();
@@ -344,8 +375,8 @@ TEST_F(AlarmReqListenerTest, SyncAlarms)
   _ms.trap_complete(3, 5);
 
   // Clear the alarm to put us back into a good state
-  EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
-                                        1000))); 
+  COLLECT_CALL(send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
+                                        1000), _, _));
   _alarm_1.clear();
   _ms.trap_complete(1, 5);
 }
@@ -357,17 +388,17 @@ TEST_F(AlarmReqListenerTest, AlarmFilter)
   {
     InSequence s;
 
-    EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::ACTIVE,
-                                          1000)));
+    COLLECT_CALL(send_v2trap(TrapVars(TrapVarsMatcher::ACTIVE,
+                                      1000), _, _));
 
-    EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
-                                          1000)));
+    COLLECT_CALL(send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
+                                      1000), _, _));
 
-    EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::ACTIVE,
-                                          1001)));
+    COLLECT_CALL(send_v2trap(TrapVars(TrapVarsMatcher::ACTIVE,
+                                      1001), _, _));
 
-    EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
-                                          1001)));
+    COLLECT_CALL(send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
+                                      1001), _, _));
   }
 
   for (int idx = 0; idx < 10; idx++)
@@ -389,17 +420,17 @@ TEST_F(AlarmReqListenerTest, AlarmFilterClean)
   {
     InSequence s;
 
-    EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::ACTIVE,
-                                          1000)));
+    COLLECT_CALL(send_v2trap(TrapVars(TrapVarsMatcher::ACTIVE,
+                                      1000), _, _));
 
-    EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::ACTIVE,
-                                          1001)));
+    COLLECT_CALL(send_v2trap(TrapVars(TrapVarsMatcher::ACTIVE,
+                                      1001), _, _));
 
-    EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
-                                          1000)));
+    COLLECT_CALL(send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
+                                      1000), _, _));
 
-    EXPECT_CALL(_ms, send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
-                                          1001)));
+    COLLECT_CALL(send_v2trap(TrapVars(TrapVarsMatcher::CLEAR,
+                                      1001), _, _));
   }
 
   _alarm_1.set();
@@ -417,9 +448,53 @@ TEST_F(AlarmReqListenerTest, AlarmFilterClean)
   _ms.trap_complete(2, 5);
 }
 
+TEST_F(AlarmReqListenerTest, AlarmFailedToSend)
+{
+  advance_time_ms(AlarmFilter::CLEAN_FILTER_TIME + 1);
+
+  snmp_callback callback;
+  void* correlator;
+  EXPECT_CALL(_ms, send_v2trap(_, _, _)).
+    WillOnce(DoAll(SaveArg<1>(&callback),
+                   SaveArg<2>(&correlator)));
+  _alarm_1.set();
+  _ms.trap_complete(1, 5);
+
+  // Now report the send as failed
+  COLLECT_CALL(send_v2trap(_, _, _));
+  callback(NETSNMP_CALLBACK_OP_SEND_FAILED, NULL, 2, NULL, correlator);
+  _ms.trap_complete(1, 5);
+
+  COLLECT_CALL(send_v2trap(_, _, _));
+  _alarm_1.clear();
+  _ms.trap_complete(1, 5);
+}
+
+TEST_F(AlarmReqListenerTest, AlarmFailedToSendClearedInInterval)
+{
+  advance_time_ms(AlarmFilter::CLEAN_FILTER_TIME + 1);
+
+  snmp_callback callback;
+  void* correlator;
+  EXPECT_CALL(_ms, send_v2trap(_, _, _)).
+    WillOnce(DoAll(SaveArg<1>(&callback),
+                   SaveArg<2>(&correlator)));
+  _alarm_1.set();
+  _ms.trap_complete(1, 5);
+
+  // Clear the alarm
+  COLLECT_CALL(send_v2trap(_, _, _));
+  _alarm_1.clear();
+  _ms.trap_complete(1, 5);
+
+  // Now report the send as failed which will not attempt to resend the
+  // alarm.
+  callback(NETSNMP_CALLBACK_OP_SEND_FAILED, NULL, 2, NULL, correlator);
+}
+
 TEST_F(AlarmReqListenerTest, InvalidZmqRequest)
 {
-  EXPECT_CALL(_ms, send_v2trap(_)).
+  EXPECT_CALL(_ms, send_v2trap(_, _, _)).
     Times(0);
 
   invalid_zmq_request();
@@ -430,7 +505,7 @@ TEST_F(AlarmReqListenerTest, InvalidZmqRequest)
 
 TEST_F(AlarmReqListenerTest, InvalidAlarmIdentifier)
 {
-  EXPECT_CALL(_ms, send_v2trap(_)).
+  EXPECT_CALL(_ms, send_v2trap(_, _, _)).
     Times(0);
 
   issue_malformed_alarm();
@@ -441,7 +516,7 @@ TEST_F(AlarmReqListenerTest, InvalidAlarmIdentifier)
 
 TEST_F(AlarmReqListenerTest, UnknownAlarmIdentifier)
 {
-  EXPECT_CALL(_ms, send_v2trap(_)).
+  EXPECT_CALL(_ms, send_v2trap(_, _, _)).
     Times(0);
 
   issue_unknown_alarm();

--- a/ut/fakenetsnmp.cpp
+++ b/ut/fakenetsnmp.cpp
@@ -141,11 +141,11 @@ int netsnmp_table_container_register(netsnmp_handler_registration *reginfo,
   return 0;
 }
 
-void send_v2trap(netsnmp_variable_list *variable_list)
+void send_v2trap(netsnmp_variable_list *variable_list, snmp_callback callback, void* correlator)
 {
   if (netsnmp_intf_p)
   {
-    netsnmp_intf_p->send_v2trap(variable_list);
+    netsnmp_intf_p->send_v2trap(variable_list, callback, correlator);
 
     netsnmp_intf_p->trap_signal();
   }

--- a/ut/fakenetsnmp.h
+++ b/ut/fakenetsnmp.h
@@ -49,7 +49,7 @@ class NetSnmpInterface
 public:
   NetSnmpInterface();
 
-  virtual void send_v2trap(netsnmp_variable_list *) = 0;
+  virtual void send_v2trap(netsnmp_variable_list *, snmp_callback, void*) = 0;
 
   bool trap_complete(int count, int timeout);
   void trap_signal();
@@ -69,7 +69,7 @@ private:
 class MockNetSnmpInterface : public NetSnmpInterface
 {
 public:
-  MOCK_METHOD1(send_v2trap, void(netsnmp_variable_list *));
+  MOCK_METHOD3(send_v2trap, void(netsnmp_variable_list *, snmp_callback, void*));
 };
 
 void cwtest_intercept_netsnmp(NetSnmpInterface* intf);


### PR DESCRIPTION
Registers for callbacks when sending SNMP alarms and, if the send failed **and** the alarm is still active, resend the TRAP.

The only slight nasty is that I have to clone the `AlarmTableDef` object to use as the alarm correlator, which then gets cleaned up after the callback pops.  You'll see in the UTs I've added a utility function that sorts this out in the tests if all they need is for the alarm to succeed.