### PR TITLE
[Reviewer: Chris] Remove the option of clearing all alarms before resyncing - this no l…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ cw_alarm_agent_CPPFLAGS := ${AGENT_COMMON_CPPFLAGS}
 cw_alarm_test_CPPFLAGS := ${AGENT_COMMON_CPPFLAGS}
 cw_alarm_fvtest_CPPFLAGS := ${AGENT_COMMON_CPPFLAGS}
 
-cw_alarm_test_COVERAGE_EXCLUSIONS := ^modules/rapidjson|^modules/cpp-common/test_utils|^modules/cpp-common/include|^modules/cpp-common/src|alarm_active_table.cpp|alarm_model_table.cpp|itu_alarm_table.cpp
+cw_alarm_test_COVERAGE_EXCLUSIONS := ^modules/rapidjson|^modules/cpp-common/test_utils|^modules/cpp-common/include|^modules/cpp-common/src|alarm_active_table.cpp|alarm_model_table.cpp|itu_alarm_table.cpp|alarm_table_defs.hpp
 cw_alarm_fvtest_COVERAGE_EXCLUSIONS := ^modules/rapidjson|^modules/cpp-common/test_utils|^modules/cpp-common/include|^modules/cpp-common/src|alarm_req_listener.cpp|alarm_trap_sender.cpp|alarm_trap_sender.hpp|alarm_table_defs.cpp
 
 AGENT_COMMON_LDFLAGS := -lzmq \

--- a/alarm_req_listener.cpp
+++ b/alarm_req_listener.cpp
@@ -238,11 +238,7 @@ void AlarmReqListener::listener()
     }
     else if ((msg[0].compare("sync-alarms") == 0) && (msg.size() == 1))
     {
-      AlarmTrapSender::get_instance().sync_alarms(true);
-    }
-    else if ((msg[0].compare("sync-alarms-no-clear") == 0) && (msg.size() == 1))
-    {
-      AlarmTrapSender::get_instance().sync_alarms(false);
+      AlarmTrapSender::get_instance().sync_alarms();
     }
     else if ((msg[0].compare("poll") == 0) && (msg.size() == 1))
     {

--- a/alarm_trap_sender.cpp
+++ b/alarm_trap_sender.cpp
@@ -163,8 +163,6 @@ void AlarmTrapSender::issue_alarm(const std::string& issuer, const std::string& 
 
 void AlarmTrapSender::sync_alarms()
 {
-  AlarmTableDefs& defs = AlarmTableDefs::get_instance();
-
   for (ObservedAlarmsIterator it = _observed_alarms.begin(); it != _observed_alarms.end(); it++)
   {
     send_trap(it->alarm_table_def());

--- a/alarm_trap_sender.cpp
+++ b/alarm_trap_sender.cpp
@@ -161,20 +161,9 @@ void AlarmTrapSender::issue_alarm(const std::string& issuer, const std::string& 
   }
 }
 
-void AlarmTrapSender::sync_alarms(bool do_clear)
+void AlarmTrapSender::sync_alarms()
 {
   AlarmTableDefs& defs = AlarmTableDefs::get_instance();
-
-  if (do_clear)
-  {
-    for (AlarmTableDefsIterator it = defs.begin(); it != defs.end(); it++)
-    {
-      if (it->severity() == AlarmDef::CLEARED)
-      {
-        send_trap(*it);
-      }
-    }
-  }
 
   for (ObservedAlarmsIterator it = _observed_alarms.begin(); it != _observed_alarms.end(); it++)
   {

--- a/alarm_trap_sender.hpp
+++ b/alarm_trap_sender.hpp
@@ -158,7 +158,7 @@ public:
   void issue_alarm(const std::string& issuer, const std::string& identifier);
 
   // Generates alarmClearState INFORMs corresponding to each of the currently
-  // cleared alarms and alarmActiveState informs for each currently active
+  // cleared alarms and alarmActiveState INFORMs for each currently active
   // alarm.
   void sync_alarms();
 

--- a/alarm_trap_sender.hpp
+++ b/alarm_trap_sender.hpp
@@ -157,10 +157,10 @@ public:
   // to filtering).
   void issue_alarm(const std::string& issuer, const std::string& identifier);
 
-  // Optionally generates alarmClearState informs corresponding to each of
-  // the alarms defined for this node; followed by alarmActiveState informs
-  // for each currently active alarm.
-  void sync_alarms(bool do_clear);
+  // Generates alarmClearState INFORMs corresponding to each of the currently
+  // cleared alarms and alarmActiveState informs for each currently active
+  // alarm.
+  void sync_alarms();
 
   static AlarmTrapSender& get_instance() {return _instance;}
 private:


### PR DESCRIPTION
…onger makes sense

Fixes #134.

I'll test by running "resync" on a system with one alarm active, and testing that no clear notification is sent for that alarm.