### PR TITLE
[Reviewer: Andrew] Fix up warnings when compiling with clang

### DIFF
--- a/alarm_active_table.cpp
+++ b/alarm_active_table.cpp
@@ -289,7 +289,7 @@ alarmActiveTable_SNMPDateTime alarm_time_issued(void)
   // tells us how offset (in seconds) from UTC we are and stores a 
   // broken down time representation in the structure timing
   timing = *localtime(&rawtime);
-  UTC_offset = abs(timezone) / 3600;
+  UTC_offset = std::abs(timezone) / 3600;
   // htons converts the integer from host byte order to network
   // byte order as specified in RFC 2579.
   d_time.year = htons(1900 + timing.tm_year);
@@ -301,7 +301,7 @@ alarmActiveTable_SNMPDateTime alarm_time_issued(void)
   d_time.decisecond = 0;
   d_time.direction = (timezone > 0) ? '+' : '-';
   d_time.timegeozone = UTC_offset;
-  d_time.mintimezone = (abs(timezone) % 3600) / 60;
+  d_time.mintimezone = (std::abs(timezone) % 3600) / 60;
   return d_time;
 }
 

--- a/ut/alarm_tables_testing.cpp
+++ b/ut/alarm_tables_testing.cpp
@@ -97,8 +97,8 @@ TEST_F(CustomDefs, ituAlarmTable)
   //details of the mapping to AlarmModelState see
   //https://tools.ietf.org/html/rfc3877#section-5.4
   ASSERT_STREQ("\"Test alarm raised details\"\n", snmp_get_raw(ituAlarmTable_entry + "." + itu_details + ".0.6666." + str_severity_raised, buf, sizeof(buf)));
-  ASSERT_EQ(163, snmp_get(ituAlarmTable_entry + "." + itu_cause + ".0.6666." + str_cleared));
-  ASSERT_EQ(163, snmp_get(ituAlarmTable_entry + "." + itu_cause + ".0.6666." + str_severity_raised));
+  ASSERT_EQ(163u, snmp_get(ituAlarmTable_entry + "." + itu_cause + ".0.6666." + str_cleared));
+  ASSERT_EQ(163u, snmp_get(ituAlarmTable_entry + "." + itu_cause + ".0.6666." + str_severity_raised));
 }
 
 TEST_F(CustomDefs, ActiveTableMultipleAlarms)
@@ -128,7 +128,7 @@ TEST_F(CustomDefs, ActiveTableMultipleAlarms)
 
   // Checks that the table has the right number of entries. Each alarm has 11
   // columns and there should be 2 alarms raised.
-  ASSERT_EQ(22, entries.size());
+  ASSERT_EQ(22u, entries.size());
   
   // Clears remaining alarms.
   alarmActiveTable_trap_handler(*def3_cleared);
@@ -136,7 +136,7 @@ TEST_F(CustomDefs, ActiveTableMultipleAlarms)
 
   // Checks there are now no entries in the table
   std::vector<std::string> entries_update = snmp_walk(alarmActiveTable_table);
-  ASSERT_EQ(0, entries_update.size());
+  ASSERT_EQ(0u, entries_update.size());
 }
 
 TEST_F(CustomDefs, ActiveTableRepeatAlarm)
@@ -153,14 +153,14 @@ TEST_F(CustomDefs, ActiveTableRepeatAlarm)
   // Checks that the table has the right number of entries. The second alarm
   // raised was identical to the first and hence there should only be one entry
   // which has 11 columns.
-  ASSERT_EQ(11, entries.size());
+  ASSERT_EQ(11u, entries.size());
 
   // Clears the alarm.
   alarmActiveTable_trap_handler(*def_cleared);
 
   // Checks there are now no entries in the table
   std::vector<std::string> entries_update = snmp_walk(alarmActiveTable_table);
-  ASSERT_EQ(0, entries_update.size());
+  ASSERT_EQ(0u, entries_update.size());
 }
 
 TEST_F(CustomDefs, ActiveTableClearingUnraisedAlarm)
@@ -170,7 +170,7 @@ TEST_F(CustomDefs, ActiveTableClearingUnraisedAlarm)
 
   // Checks there are no entries in the table
   std::vector<std::string> entries_update = snmp_walk(alarmActiveTable_table);
-  ASSERT_EQ(0, entries_update.size());
+  ASSERT_EQ(0u, entries_update.size());
 }
 
 TEST_F(CustomDefs, ActiveTableSameAlarmDifferentSeverities)
@@ -186,7 +186,7 @@ TEST_F(CustomDefs, ActiveTableSameAlarmDifferentSeverities)
   // Checks that the table has the right number of entries. The second alarm
   // should have overwritten the first and hence there should only be one entry
   // with 11 columns.
-  ASSERT_EQ(11, entries.size()); 
+  ASSERT_EQ(11u, entries.size()); 
 
   // Calculates which column should contain the alarm description based off the
   // column number definitions within alarm_active_table.hpp  
@@ -198,7 +198,7 @@ TEST_F(CustomDefs, ActiveTableSameAlarmDifferentSeverities)
   // Clears the alarm and checks there are now no entries in the table.
   alarmActiveTable_trap_handler(*def_cleared);
   std::vector<std::string> entries_update = snmp_walk(alarmActiveTable_table);
-  ASSERT_EQ(0, entries_update.size());
+  ASSERT_EQ(0u, entries_update.size());
 }
 
 TEST_F(CustomDefs, ActiveTableIndexTimeStamp)
@@ -245,7 +245,7 @@ TEST_F(CustomDefs, AlarmTableIndexSize)
   
   // Checks the index of the first alarm contains 26 elements as defined
   // in RFC 3877.
-  ASSERT_EQ(26, index_fields.size());
+  ASSERT_EQ(26u, index_fields.size());
 }
 
 TEST_F(CustomDefs, AlarmTableAlarmsIndex)


### PR DESCRIPTION
This fixes up a couple of compiler warnings I saw when compiling with a newer compiler (Clang 3.8):

* preferring std::abs to abs when getting absolute values (http://stackoverflow.com/questions/21392627/abs-vs-stdabs-what-does-the-reference-say)
* explicitly marking integer literals as unsigned, if we're comparing them to unsigned values