### PR TITLE
[Reviewer: Andrew] Allow running UT without /var/run/clearwater

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,19 +75,6 @@ BUILD_DIR := build
 
 include build-infra/cpp.mk
 
-# As a special case, running the agent test needs /var/run/clearwater to exist on the local machine
-run_cw_alarm_test : | /var/run/clearwater
-run_cw_alarm_fvtest : | /var/run/clearwater
-debug_cw_alarm_test : | /var/run/clearwater
-debug_cw_alarm_fvtest : | /var/run/clearwater
-valgrind_cw_alarm_test : | /var/run/clearwater
-valgrind_cw_alarm_fvtest : | /var/run/clearwater
-valgrind_check_cw_alarm_test : | /var/run/clearwater
-valgrind_check_cw_alarm_fvtest : | /var/run/clearwater
-/var/run/clearwater :
-	sudo mkdir -p $@
-	sudo chmod -R o+wr /var/run/clearwater
-
 DEB_COMPONENT := clearwater-snmp-handlers
 DEB_MAJOR_VERSION := 1.0${DEB_VERSION_QUALIFIER}
 DEB_NAMES := clearwater-snmp-handler-cdiv clearwater-snmp-alarm-agent clearwater-snmp-handler-memento-as clearwater-snmp-handler-memento clearwater-snmp-handler-astaire

--- a/alarm_req_listener.cpp
+++ b/alarm_req_listener.cpp
@@ -142,7 +142,11 @@ bool AlarmReqListener::zmq_init_sck()
   int linger = 0;
   zmq_setsockopt(_sck, ZMQ_LINGER, &linger, sizeof(linger));
 
+#ifdef UNIT_TEST
+  std::string sck_file = std::string("/tmp/ut-alarms-socket-" + std::to_string(getpid()));
+#else
   std::string sck_file = std::string("/var/run/clearwater/alarms");
+#endif
   std::string sck_url = std::string("ipc://" + sck_file);
   TRC_INFO("AlarmReqListener: ss='%s'", sck_url.c_str());
 


### PR DESCRIPTION
Previously, these UTs had to be run as root (at least once) because they needed to create /var/run/clearwater. This changes the alarm location we use in UT to a file in /tmp, so that it doesn't need to run as root.