### PR TITLE
[Reviewer: Alex, Andrew] Fix alarm resend

### DIFF
--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -8,3 +8,4 @@
 /clearwater-snmp-handler-memento/
 /clearwater-snmp-handler-astaire/
 /clearwater-snmp-alarm-agent/
+/clearwater-snmp-alarm-agent-dbg/

--- a/include/alarm_trap_sender.hpp
+++ b/include/alarm_trap_sender.hpp
@@ -170,7 +170,6 @@ public:
   // @param peer - The SNMP peer that failed
   // @param alarm_table_def - The alarm entry that was being raised
   void alarm_trap_send_callback(int op,
-                                const std::string& peer,
                                 const AlarmTableDef& alarm_table_def);
 
   static AlarmTrapSender& get_instance() {return _instance;}


### PR DESCRIPTION
Alex, Andrew,

Please can you review my fix to get alarm (INFORM) resending?  I've tested live, but I don't have a server that will respond positively to INFORMs, so I haven't seen the non-resend behavior - Andrew, I think you said you'd be OK to test this as part of your testing.

There are three changes here.

*   We can't get access to the peer IP address.  Rather than enhancing net-snmp to plumb this through, I've just removed the trace statements (which were the only use).
*   We cloned the AlarmTableDef to pass to net-snmp, but since the AlarmTableDefs are all persistent anyway, I think we can just pass the actual pointer to it.  This means we don't have to worry about when to delete the copy (which is far from trivial to determine).
*   (The .gitignore change is just a tidy-up.)

Cheers,

Matt