### PR TITLE
[Reviewer: Matt] Put the monit Before directive in the right place

### DIFF
--- a/debian/clearwater-snmp-alarm-agent.service
+++ b/debian/clearwater-snmp-alarm-agent.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Clearwater SNMP alarm agent
+Before=clearwater-monit.service
 
 [Service]
 ExecStart=/usr/share/clearwater/bin/clearwater-snmp-alarm-agent-wrapper
@@ -9,4 +10,3 @@ LimitCORE=infinity
 
 [Install]
 WantedBy=clearwater-monit.service
-Before=clearwater-monit.service


### PR DESCRIPTION
Small fix to put to the clearwater-snmp-alarm-agent.service unit file (one of the values was in the wrong section).

I've tested live by running `sudo systemctl daemon-reload` to reload systemd's config. Before the change I got the following in /var/log/messages, now messages is clean. 

```
Jun 30 13:49:47 ip-10-0-7-154 systemd: [/etc/systemd/system/clearwater-snmp-alarm-agent.service:12] Unknown lvalue 'Before' in section 'Install'
```