### PR TITLE
[Reviewer: Matt] Triggers rework

### DIFF
--- a/clearwater-snmp-alarm-agent.root/usr/share/clearwater/install/triggers/clearwater-snmp-alarm-agent
+++ b/clearwater-snmp-alarm-agent.root/usr/share/clearwater/install/triggers/clearwater-snmp-alarm-agent
@@ -1,0 +1,13 @@
+#!/bin/bash
+SERVICE=clearwater-snmp-alarm-agent
+
+# Restart the alarm agent.  The alarm agent is managed either by systemctl (on
+# centos) or upstart (on ubuntu). Detect which one is installed and restart the
+# agent appropriately.
+if which systemctl >/dev/null 2>&1; then
+  systemctl restart $SERVICE
+else
+  restart $SERVICE
+fi
+
+exit 0

--- a/clearwater-snmp-alarm-agent.root/usr/share/clearwater/install/triggers/clearwater-snmp-alarm-agent
+++ b/clearwater-snmp-alarm-agent.root/usr/share/clearwater/install/triggers/clearwater-snmp-alarm-agent
@@ -1,4 +1,38 @@
 #!/bin/bash
+# @file clearwater-snmp-alarm-agent
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2016  Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
 SERVICE=clearwater-snmp-alarm-agent
 
 # Restart the alarm agent.  The alarm agent is managed either by systemctl (on

--- a/debian/clearwater-snmp-alarm-agent.postinst
+++ b/debian/clearwater-snmp-alarm-agent.postinst
@@ -61,9 +61,7 @@ case "$1" in
     ;;
 
     triggered)
-        # Restart the alarm agent. Use restart rather than stop
-        # as the alarm agent is covered by upstart not monit
-        restart clearwater-snmp-alarm-agent || /bin/true
+        /usr/share/clearwater/install/triggers/clearwater-snmp-alarm-agent
     ;;
 
     *)


### PR DESCRIPTION
Hi Matt, please can you review this PR to rework the alarm agent's triggers.

The PR makes two changes: 

* Refactors the processing that is involved when the agent is triggered into a separate script which can be called directly. This is needed on centos which has a less rich triggering infrastructure. 
* Makes the triggering logic work on ubuntu and centos. 

This means that packages which want to trigger the alarm agent can either call the script directly, or use the existing debian triggering mechanism (which maps through to the script). This means we don't have to go through all our debian packages and change them immediately; we can do this as we port them to work on centos. I don't think this technical debt will cost us very much.

I've tested live with:

* A centos package that calls the trigger script directly
* A debian package that calls the trigger script directly
* A debian package that uses the built-in debian triggers mechanism