### PR TITLE
[Reviewer: Ellie] Set hostname in enterprise alarms

### DIFF
--- a/CLEARWATER-ENTERPRISE-MIB
+++ b/CLEARWATER-ENTERPRISE-MIB
@@ -102,7 +102,8 @@ alarmTrapsPrefix OBJECT IDENTIFIER ::= { clearwaterTraps 0 }
                    alarmTrapDetails,
                    alarmTrapCause,
                    alarmTrapEffect,
-                   alarmTrapAction
+                   alarmTrapAction,
+                   alarmTrapHostname
                    }
     STATUS       current
     DESCRIPTION  "A collection of objects providing information about the
@@ -194,12 +195,14 @@ alarmTrapsPrefix OBJECT IDENTIFIER ::= { clearwaterTraps 0 }
     DESCRIPTION  "Suggested actions that you can take to resolve the problem."
     ::= { alarmTrapsPrefix 10 }
 
+  -- alarmTrapsPrefix 11 is used for alarmTrapGroup above
+
   alarmTrapHostname OBJECT-TYPE
     SYNTAX       DisplayString (SIZE (1..4096))
     MAX-ACCESS   read-write
     STATUS       current
     DESCRIPTION  "Hostname of the network element raising this alarm."
-    ::= { alarmTrapsPrefix 11 }
+    ::= { alarmTrapsPrefix 12 }
 
 END
 

--- a/CLEARWATER-ENTERPRISE-MIB
+++ b/CLEARWATER-ENTERPRISE-MIB
@@ -118,7 +118,8 @@ alarmTrapsPrefix OBJECT IDENTIFIER ::= { clearwaterTraps 0 }
                    alarmTrapDetails,
                    alarmTrapCause,
                    alarmTrapEffect,
-                   alarmTrapAction
+                   alarmTrapAction,
+                   alarmTrapHostname
                    }
     STATUS       current
     DESCRIPTION  "This is the alarm trap table for Clearwater.  A
@@ -192,6 +193,13 @@ alarmTrapsPrefix OBJECT IDENTIFIER ::= { clearwaterTraps 0 }
     STATUS       current
     DESCRIPTION  "Suggested actions that you can take to resolve the problem."
     ::= { alarmTrapsPrefix 10 }
+
+  alarmTrapHostname OBJECT-TYPE
+    SYNTAX       DisplayString (SIZE (1..4096))
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION  "Hostname of the network element raising this alarm."
+    ::= { alarmTrapsPrefix 11 }
 
 END
 

--- a/clearwater-snmp-alarm-agent.root/usr/share/clearwater/bin/clearwater-snmp-alarm-agent-wrapper
+++ b/clearwater-snmp-alarm-agent.root/usr/share/clearwater/bin/clearwater-snmp-alarm-agent-wrapper
@@ -48,10 +48,10 @@ get_daemon_args()
   # Don't try and load MIBS at startup - we don't need them and this just causes lots of
   # "missing MIB" error logs.
   export MIBS=""
-  ption=value
   DAEMON_ARGS="
                --snmp-ips=$snmp_ip 
-               --local_ip=$local_ip
+               --local-ip=$local_ip
+               --hostname=$public_hostname
                --community=$snmp_community 
                --snmp-notification-types=$snmp_notification_types
                --log-dir=$log_directory 

--- a/include/alarm_scheduler.hpp
+++ b/include/alarm_scheduler.hpp
@@ -149,7 +149,8 @@ public:
 
   // Constructor/Destructor
   AlarmScheduler(AlarmTableDefs* alarm_table_defs, 
-                 std::set<NotificationType> snmp_notifications);
+                 std::set<NotificationType> snmp_notifications,
+                 std::string hostname);
   virtual ~AlarmScheduler();
 
   // Generates an alarmActiveState inform if the identified alarm is not

--- a/include/alarm_trap_sender.hpp
+++ b/include/alarm_trap_sender.hpp
@@ -58,9 +58,11 @@ class AlarmTrapSender
 {
 public:
   void initialise(AlarmScheduler* alarm_scheduler,
-                  std::set<NotificationType> snmp_notifications)
+                  std::set<NotificationType> snmp_notifications,
+                  std::string hostname)
     { _alarm_scheduler    = alarm_scheduler;
-      _snmp_notifications = snmp_notifications; }
+      _snmp_notifications = snmp_notifications;
+      _hostname = hostname; }
 
   void send_trap(const AlarmTableDef& alarm_table_def);
 
@@ -78,6 +80,7 @@ private:
   AlarmTrapSender() : _alarm_scheduler(NULL) {}
   AlarmScheduler* _alarm_scheduler;
   std::set<NotificationType> _snmp_notifications;
+  std::string _hostname;
   static AlarmTrapSender _instance;
   // Sends an RFC3877 compliant trap based upon the specified alarm definition.
   // net-snmp will handle the retries if needed. 

--- a/src/alarm_scheduler.cpp
+++ b/src/alarm_scheduler.cpp
@@ -66,11 +66,12 @@ void SingleAlarmManager::change_schedule(AlarmDef::Severity new_severity,
 }
 
 AlarmScheduler::AlarmScheduler(AlarmTableDefs* alarm_table_defs, 
-                               std::set<NotificationType> snmp_notifications) :
+                               std::set<NotificationType> snmp_notifications,
+                               std::string hostname) :
   _terminated(false),
   _alarm_table_defs(alarm_table_defs)
 {
-  AlarmTrapSender::get_instance().initialise(this, snmp_notifications);
+  AlarmTrapSender::get_instance().initialise(this, snmp_notifications, hostname);
 
   // Create the lock/condition variables.
   pthread_mutex_init(&_lock, NULL);

--- a/src/alarm_trap_sender.cpp
+++ b/src/alarm_trap_sender.cpp
@@ -200,7 +200,7 @@ void AlarmTrapSender::send_enterprise_trap(const AlarmTableDef& alarm_table_def)
   static const oid alarm_cause_oid[] = {1,3,6,1,4,1,19444,12,2,0,8};
   static const oid alarm_effect_oid[] = {1,3,6,1,4,1,19444,12,2,0,9};
   static const oid alarm_action_oid[] = {1,3,6,1,4,1,19444,12,2,0,10};
-  static const oid alarm_hostname_oid[] = {1,3,6,1,4,1,19444,12,2,0,11};
+  static const oid alarm_hostname_oid[] = {1,3,6,1,4,1,19444,12,2,0,12};
   
   // We create variable lists, wipe them clean and then link them to each other
   // so only the first needs to be passed to sent_v2trap

--- a/src/alarm_trap_sender.cpp
+++ b/src/alarm_trap_sender.cpp
@@ -200,6 +200,7 @@ void AlarmTrapSender::send_enterprise_trap(const AlarmTableDef& alarm_table_def)
   static const oid alarm_cause_oid[] = {1,3,6,1,4,1,19444,12,2,0,8};
   static const oid alarm_effect_oid[] = {1,3,6,1,4,1,19444,12,2,0,9};
   static const oid alarm_action_oid[] = {1,3,6,1,4,1,19444,12,2,0,10};
+  static const oid alarm_hostname_oid[] = {1,3,6,1,4,1,19444,12,2,0,11};
   
   // We create variable lists, wipe them clean and then link them to each other
   // so only the first needs to be passed to sent_v2trap
@@ -214,6 +215,7 @@ void AlarmTrapSender::send_enterprise_trap(const AlarmTableDef& alarm_table_def)
   CREATE_NETSNMP_LIST(var_alarm_cause);
   CREATE_NETSNMP_LIST(var_alarm_effect);
   CREATE_NETSNMP_LIST(var_alarm_action);
+  CREATE_NETSNMP_LIST(var_alarm_hostname);
   
   var_trap.next_variable = &var_MIB_version;
   var_MIB_version.next_variable = &var_alarm_name;
@@ -225,7 +227,8 @@ void AlarmTrapSender::send_enterprise_trap(const AlarmTableDef& alarm_table_def)
   var_alarm_details.next_variable = &var_alarm_cause;
   var_alarm_cause.next_variable = &var_alarm_effect;
   var_alarm_effect.next_variable = &var_alarm_action;
-  var_alarm_action.next_variable = NULL;
+  var_alarm_action.next_variable = &var_alarm_hostname;
+  var_alarm_hostname.next_variable = NULL;
 
   // Sets the object id of each of the variable lists to the OIDs defined above,
   // these can be thought of as the keys for each of the variable bindings.
@@ -240,6 +243,7 @@ void AlarmTrapSender::send_enterprise_trap(const AlarmTableDef& alarm_table_def)
   snmp_set_var_objid(&var_alarm_cause, alarm_cause_oid, OID_LENGTH(alarm_cause_oid));
   snmp_set_var_objid(&var_alarm_effect, alarm_effect_oid, OID_LENGTH(alarm_effect_oid));
   snmp_set_var_objid(&var_alarm_action, alarm_action_oid, OID_LENGTH(alarm_action_oid));
+  snmp_set_var_objid(&var_alarm_hostname, alarm_hostname_oid, OID_LENGTH(alarm_hostname_oid));
 
   // Sets the value of each of the variable lists, these can be thought of as
   // the values which correspond to the above keys in the variable bindings.
@@ -279,6 +283,9 @@ void AlarmTrapSender::send_enterprise_trap(const AlarmTableDef& alarm_table_def)
   snmp_set_var_typed_value(&var_alarm_action, ASN_OCTET_STR, 
                            alarm_table_def.action().c_str(), 
                            alarm_table_def.action().length());
+  snmp_set_var_typed_value(&var_alarm_hostname, ASN_OCTET_STR,
+                           _hostname.c_str(),
+                           _hostname.length());
 
   // Sends the trap passing the function the first of the linked lists.
   send_v2trap(&var_trap, ::alarm_trap_send_callback, (void*)&alarm_table_def);

--- a/src/alarms_agent.cpp
+++ b/src/alarms_agent.cpp
@@ -68,6 +68,7 @@ enum OptionTypes
   OPT_COMMUNITY=256+1,
   OPT_SNMP_NOTIFICATION_TYPE,
   OPT_LOCAL_IP,
+  OPT_HOSTNAME,
   OPT_SNMP_IPS,
   OPT_LOG_LEVEL,
   OPT_LOG_DIR
@@ -78,7 +79,8 @@ const static struct option long_opt[] =
   { "community",                       required_argument, 0, OPT_COMMUNITY},
   { "snmp-notification-types",         required_argument, 0, OPT_SNMP_NOTIFICATION_TYPE},
   { "snmp-ips",                        required_argument, 0, OPT_SNMP_IPS},
-  { "local_ip",                        required_argument, 0, OPT_LOCAL_IP},
+  { "local-ip",                        required_argument, 0, OPT_LOCAL_IP},
+  { "hostname",                        required_argument, 0, OPT_HOSTNAME},
   { "log-level",                       required_argument, 0, OPT_LOG_LEVEL},
   { "log-dir",                         required_argument, 0, OPT_LOG_DIR},
 };
@@ -87,6 +89,8 @@ static void usage(void)
 {
     puts("Options:\n"
          "\n"
+         " --local-ip <ip>            Local IP address of this node\n"
+         " --hostname <name>       Hostname to identify this node in enterprise alarms\n"
          " --snmp-ips <ip>,<ip>       Send SNMP notifications to the specified IPs\n"
          " --community <name>         Include the given community string on notifications\n"
          " --snmp-notification-types  Sends SNMP notifiations with the specified format\n"
@@ -102,6 +106,7 @@ int main (int argc, char **argv)
   char* community = NULL;
   std::set<NotificationType> snmp_notifications;
   std::string local_ip = "0.0.0.0";
+  std::string hostname = "";
   std::string logdir = "";
   int loglevel = 4;
   int c;
@@ -142,7 +147,10 @@ int main (int argc, char **argv)
         Utils::split_string(optarg, ',', trap_ips);
         break;
       case OPT_LOCAL_IP:
-        local_ip = optarg;       
+        local_ip = optarg;
+        break;
+      case OPT_HOSTNAME:
+        hostname = optarg;
         break;
       case OPT_LOG_LEVEL:
         loglevel = atoi(optarg);
@@ -189,7 +197,7 @@ int main (int argc, char **argv)
     return 1;
   }
 
-  AlarmScheduler* alarm_scheduler = new AlarmScheduler(alarm_table_defs, snmp_notifications);
+  AlarmScheduler* alarm_scheduler = new AlarmScheduler(alarm_table_defs, snmp_notifications, hostname);
   AlarmReqListener* alarm_req_listener = new AlarmReqListener(alarm_scheduler);
 
   init_alarmModelTable(*alarm_table_defs);

--- a/src/alarms_agent.cpp
+++ b/src/alarms_agent.cpp
@@ -90,7 +90,7 @@ static void usage(void)
     puts("Options:\n"
          "\n"
          " --local-ip <ip>            Local IP address of this node\n"
-         " --hostname <name>       Hostname to identify this node in enterprise alarms\n"
+         " --hostname <name>          Hostname to identify this node in enterprise alarms\n"
          " --snmp-ips <ip>,<ip>       Send SNMP notifications to the specified IPs\n"
          " --community <name>         Include the given community string on notifications\n"
          " --snmp-notification-types  Sends SNMP notifiations with the specified format\n"


### PR DESCRIPTION
I suspected that https://github.com/Metaswitch/clearwater-snmp-handlers/issues/170 might be debatable as a product issue, but it makes it much easier for us to centrally manage and monitor alarms on our test systems, so I've added it.

While I was in the area, I fixed the --local_ip option to use dashes like the other options.

I'll test live once reviewed (and before merging), by installing this on a system and checking its hostname shows up in the alarm.