### PR TITLE
[Reviewer EM] Include alarm state at the end of the alarm OID

### DIFF
--- a/CLEARWATER-ENTERPRISE-MIB
+++ b/CLEARWATER-ENTERPRISE-MIB
@@ -141,7 +141,7 @@ alarmTrapsPrefix OBJECT IDENTIFIER ::= { clearwaterTraps 0 }
     SYNTAX       OBJECT IDENTIFIER 
     MAX-ACCESS   read-write
     STATUS       current
-    DESCRIPTION  "The OID of the alarmed obect.  Gets and Sets on
+    DESCRIPTION  "The OID of the alarm.  Gets and Sets on
                   this OID are supported. "
     ::= { alarmTrapsPrefix 3 }
 

--- a/src/alarm_trap_sender.cpp
+++ b/src/alarm_trap_sender.cpp
@@ -261,6 +261,7 @@ void AlarmTrapSender::send_enterprise_trap(const AlarmTableDef& alarm_table_def)
                            sizeof(model_row_oid));
 
   var_alarm_oid.val.objid[ALARMMODELTABLEROW_INDEX] = alarm_table_def.alarm_index();
+  var_alarm_oid.val.objid[ALARMMODELTABLEROW_STATE] = alarm_table_def.state();
   
   snmp_set_var_typed_value(&var_resource_id, ASN_OBJECT_ID, 
                            (u_char*) zero_dot_zero, 


### PR DESCRIPTION
Hi Ellie

Can you sign off on this change for me (we discussed last week)?  I've also tweaked the MIB text to make it clear that the OID is for the alarm itself, not the alarmed object (which wouldn't have the "state" element in it, logically)

I've done a live test and can confirm that the state now comes out in the alarm message.
