### PR TITLE
[Reviewer: CNE] Automated mib build infra fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 debian/copyright
 build
 cw_alarm_agent
-/_env/
+_env/
 
 # FV tests
 fvtest-snmpd.out

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 debian/copyright
 build
 cw_alarm_agent
+/_env/
 
 # FV tests
 fvtest-snmpd.out

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ astaire_handler.so:
 	${MAKE} -C ${CW_ALARM_AGENT_DIR} $@
 
 .PHONY: cw_alarm_agent CW_ALARM_AGENT_test cw_alarm_agent_clean cw_alarm_agent_distclean cw_mib cdiv_handler.so memento_handler.so memento_as_handler.so astaire_handler.so
+
 env: $(ENV_DIR)/bin/python
 
 $(ENV_DIR)/bin/python:

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ MK_DIR := ${ROOT}/mk
 PREFIX ?= ${ROOT}/usr
 INSTALL_DIR ?= ${PREFIX}
 MODULE_DIR := ${ROOT}/modules
+ENV_DIR := $(shell pwd)/_env
+PYTHON_BIN := $(shell which python)
 
 PKG_COMPONENT := clearwater-snmp-handlers
 PKG_MAJOR_VERSION ?= 1.0
@@ -45,8 +47,8 @@ cw_alarm_agent_clean:
 
 cw_alarm_agent_distclean: CW_ALARM_AGENT_clean
 
-cw_mib:
-	${PYTHON} ${ROOT}/mib-generator/cw_mib_generator.py && mv ${ROOT}/mib-generator/PROJECT-CLEARWATER-MIB ${ROOT}/clearwater-snmp-alarm-agent.root/usr/share/clearwater/mibs/
+cw_mib: env
+	${ENV_DIR}/bin/python ${ROOT}/mib-generator/cw_mib_generator.py && mv ${ROOT}/mib-generator/PROJECT-CLEARWATER-MIB ${ROOT}/clearwater-snmp-alarm-agent.root/usr/share/clearwater/mibs/
 
 cdiv_handler.so:
 	${MAKE} -C ${CW_ALARM_AGENT_DIR} $@
@@ -61,6 +63,12 @@ astaire_handler.so:
 	${MAKE} -C ${CW_ALARM_AGENT_DIR} $@
 
 .PHONY: cw_alarm_agent CW_ALARM_AGENT_test cw_alarm_agent_clean cw_alarm_agent_distclean cw_mib cdiv_handler.so memento_handler.so memento_as_handler.so astaire_handler.so
+env: $(ENV_DIR)/bin/python
+
+$(ENV_DIR)/bin/python:
+	virtualenv --setuptools --python=$(PYTHON_BIN) $(ENV_DIR)
+	$(ENV_DIR)/bin/easy_install docopt
+
 build: ${SUBMODULES} cw_alarm_agent cw_mib
 
 test: ${SUBMODULES} cw_alarm_agent_test
@@ -69,9 +77,15 @@ full_test: ${SUBMODULES} cw_alarm_agent_full_test
 
 testall: $(patsubst %, %_test, ${SUBMODULES}) full_test
 
-clean: $(patsubst %, %_clean, ${SUBMODULES}) cw_alarm_agent_clean
+clean: $(patsubst %, %_clean, ${SUBMODULES}) cw_alarm_agent_clean pyclean envclean
 	rm -rf ${ROOT}/usr
 	rm -rf ${ROOT}/build
+
+pyclean:
+	find src -name \*.pyc -exec rm {} \;
+
+envclean:
+	rm -rf $(ENV_DIR)
 
 distclean: $(patsubst %, %_distclean, ${SUBMODULES}) cw_alarm_agent_distclean
 	rm -rf ${ROOT}/usr
@@ -85,5 +99,5 @@ include build-infra/cw-rpm.mk
 .PHONY: rpm
 rpm: build rpm-only
 
-.PHONY: all build test clean distclean
+.PHONY: all env build test clean pyclean envclean distclean
 

--- a/Makefile
+++ b/Makefile
@@ -77,12 +77,9 @@ full_test: ${SUBMODULES} cw_alarm_agent_full_test
 
 testall: $(patsubst %, %_test, ${SUBMODULES}) full_test
 
-clean: $(patsubst %, %_clean, ${SUBMODULES}) cw_alarm_agent_clean pyclean envclean
+clean: $(patsubst %, %_clean, ${SUBMODULES}) cw_alarm_agent_clean envclean
 	rm -rf ${ROOT}/usr
 	rm -rf ${ROOT}/build
-
-pyclean:
-	find src -name \*.pyc -exec rm {} \;
 
 envclean:
 	rm -rf $(ENV_DIR)
@@ -99,5 +96,5 @@ include build-infra/cw-rpm.mk
 .PHONY: rpm
 rpm: build rpm-only
 
-.PHONY: all env build test clean pyclean envclean distclean
+.PHONY: all env build test clean envclean distclean
 


### PR DESCRIPTION
Fix to my recent PR. I was using the default Python environment for the script, which caused issues on a build system where docopt was not installed in the default environment.

This PR modifies the Makefile to create a virtualenv for the mib generator. Instead of using a `_setup.py` script for setting up the environment, like most of our Python packages, I felt it more appropriate to go with the simpler approach here - those setup scripts are aimed at installable Python packages, rather than a script executed at build time, and the only non-default package we need is docopt. I also only included `envclean` and not `pyclean`, as we don't generate any eggs, compiled Python code, or Python coverage reports.