### PR TITLE
[Reviewer: CNE] Add output directory argument to MIB generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ cw_alarm_agent_clean:
 cw_alarm_agent_distclean: CW_ALARM_AGENT_clean
 
 cw_mib: env
-	${ENV_DIR}/bin/python ${ROOT}/mib-generator/cw_mib_generator.py && mv ${ROOT}/mib-generator/PROJECT-CLEARWATER-MIB ${ROOT}/clearwater-snmp-alarm-agent.root/usr/share/clearwater/mibs/
+	${ENV_DIR}/bin/python ${ROOT}/mib-generator/cw_mib_generator.py ${ROOT}/clearwater-snmp-alarm-agent.root/usr/share/clearwater/mibs/
 
 cdiv_handler.so:
 	${MAKE} -C ${CW_ALARM_AGENT_DIR} $@

--- a/mib-generator/cw_mib_generator.py
+++ b/mib-generator/cw_mib_generator.py
@@ -64,7 +64,7 @@ def main(args):
     if args['--cwc-mib-dir']:
         cwc_dir = os.path.abspath(args['--cwc-mib-dir'])
 
-        print("Generating Clearwater Core MIB at {}".format(cwc_dir))
+        print("Generating Clearwater Core MIB at {}".format(output_dir))
         generate_mib(common_dir,
                      cwc_dir,
                      output_dir,
@@ -75,7 +75,7 @@ def main(args):
     else:
         # PC MIB fragment is found in the common directory, so supply
         # common_dir as the extras directory also.
-        print("Generating Project Clearwater MIB at {}".format(common_dir))
+        print("Generating Project Clearwater MIB at {}".format(output_dir))
         generate_mib(common_dir,
                      common_dir,
                      output_dir,

--- a/mib-generator/cw_mib_generator.py
+++ b/mib-generator/cw_mib_generator.py
@@ -8,11 +8,14 @@
 # Metaswitch Networks in a separate written agreement.
 
 """Metaswitch Clearwater MIB Generator
-Generates the complete Project Clearwater MIB from base fragments.
+Generates the complete PROJECT-CLEARWATER-MIB from base fragments.
 If the location of the Clearwater Core MIB fragment is supplied, the
-Clearwater Core MIB will be generated instead.
+METASWITCH-CLEARWATER-CORE-MIB will be generated instead.
 
 Script should be run directly using Python 2.7 or >3.3.
+
+NOTE: If the supplied output directory already contains a file with the same
+name as the output MIB, it will be over-written!
 
 Usage:
   cw_mib_generator.py [--cwc-mib-dir=DIR] OUTPUT_DIR

--- a/mib-generator/cw_mib_generator.py
+++ b/mib-generator/cw_mib_generator.py
@@ -9,8 +9,8 @@
 
 """Metaswitch Clearwater MIB Generator
 Generates the complete Project Clearwater MIB from base fragments.
-Optionally takes the location of a Clearwater Core MIB fragment to also
-output a complete Clearwater Core MIB.
+If the location of the Clearwater Core MIB fragment is supplied, the
+Clearwater Core MIB will be generated instead.
 
 Script should be run directly using Python 2.7 or >3.3.
 

--- a/mib-generator/cw_mib_generator.py
+++ b/mib-generator/cw_mib_generator.py
@@ -15,7 +15,10 @@ output a complete Clearwater Core MIB.
 Script should be run directly using Python 2.7 or >3.3.
 
 Usage:
-  cw_mib_generator.py [--cwc-mib-dir=DIR]
+  cw_mib_generator.py [--cwc-mib-dir=DIR] OUTPUT_DIR
+
+Arguments:
+    OUTPUT_DIR       Directory for writing output MIBs
 
 Options:
   --cwc-mib-dir=DIR  Directory containing Clearwater Core MIB fragment
@@ -41,8 +44,8 @@ PC_EXTRAS = "CLEARWATER-MIB-PC-EXTRAS"
 CWC_EXTRAS = "CLEARWATER-MIB-CWC-EXTRAS"
 
 # Names of the completed output MIB files
-PC_OUTPUT_MIB = "PROJECT-CLEARWATER-MIB"
-CWC_OUTPUT_MIB = "METASWITCH-CLEARWATER-CORE-MIB"
+PC_MIB_NAME = "PROJECT-CLEARWATER-MIB"
+CWC_MIB_NAME = "METASWITCH-CLEARWATER-CORE-MIB"
 
 # MIBs must only be modified via the fragments and not the auto-generated
 # files - so add this extra statement to the auto-generated MIBs.
@@ -56,13 +59,18 @@ def main(args):
     for Clearwater Core.
     """
     common_dir = os.path.dirname(os.path.realpath(__file__))
+    output_dir = os.path.abspath(args['OUTPUT_DIR'])
 
     if args['--cwc-mib-dir']:
         cwc_dir = os.path.abspath(args['--cwc-mib-dir'])
 
         print("Generating Clearwater Core MIB at {}".format(cwc_dir))
-        generate_mib(
-            common_dir, cwc_dir, COMMON_MIB, CWC_EXTRAS, CWC_OUTPUT_MIB)
+        generate_mib(common_dir,
+                     cwc_dir,
+                     output_dir,
+                     COMMON_MIB,
+                     CWC_EXTRAS,
+                     CWC_MIB_NAME)
         print("Successfully generated Clearwater Core MIB!")
     else:
         print("No Clearwater Core MIB directory supplied, building Project "
@@ -71,11 +79,21 @@ def main(args):
     # PC MIB fragment is found in the common directory, so supply common_dir
     # as the extras directory also.
     print("Generating Project Clearwater MIB at {}".format(common_dir))
-    generate_mib(common_dir, common_dir, COMMON_MIB, PC_EXTRAS, PC_OUTPUT_MIB)
+    generate_mib(common_dir,
+                 common_dir,
+                 output_dir,
+                 COMMON_MIB,
+                 PC_EXTRAS,
+                 PC_MIB_NAME)
     print("Successfully generated Project Clearwater MIB!")
 
 
-def generate_mib(common_dir, extras_dir, common_mib, extras_mib, output_mib):
+def generate_mib(common_dir,
+                 extras_dir,
+                 output_dir,
+                 common_mib_name,
+                 extras_mib_name,
+                 output_mib_name):
     """
     Generates a MIB file by combining a common MIB fragment and an extra MIB
     fragment. The output MIB is written to the same directory as the extra
@@ -84,15 +102,16 @@ def generate_mib(common_dir, extras_dir, common_mib, extras_mib, output_mib):
     Args:
         common_dir (str): Directory containing common MIB fragment.
         extras_dir (str): Directory containing extra MIB fragment.
-        common_mib (str): File name of common MIB.
-        extras_mib (str): File name of extras MIB.
-        output_mib (str): File name for writing output MIB. NOTE: This will
-            over-write any existing file with the given name in extras_dir!
+        output_dir (str): Output directory for full MIB.
+        common_mib_name (str): File name of common MIB.
+        extras_mib_name (str): File name of extras MIB.
+        output_mib_name (str): File name for full MIB. NOTE: If this file
+            already exists in output_dir, it will be over-written!
     """
 
-    common_mib_path = os.path.join(common_dir, common_mib)
-    extras_mib_path = os.path.join(extras_dir, extras_mib)
-    output_mib_path = os.path.join(extras_dir, output_mib)
+    common_mib_path = os.path.join(common_dir, common_mib_name)
+    extras_mib_path = os.path.join(extras_dir, extras_mib_name)
+    output_mib_path = os.path.join(output_dir, output_mib_name)
 
     # The MIB title line is templated, as it needs to contain the file name of
     # the MIB. The EDIT_STATEMENT is also added after the title - we don't
@@ -100,7 +119,7 @@ def generate_mib(common_dir, extras_dir, common_mib, extras_mib, output_mib):
     raw_common_data = read_mib_fragment(common_mib_path)
     common_src_template = Template(raw_common_data)
     title_statement = "{} DEFINITIONS ::= BEGIN\n\n{}".format(
-        output_mib, EDIT_STATEMENT)
+        output_mib_name, EDIT_STATEMENT)
     substitute_dict = {'title_statement': title_statement}
 
     try:

--- a/mib-generator/cw_mib_generator.py
+++ b/mib-generator/cw_mib_generator.py
@@ -73,19 +73,16 @@ def main(args):
                      CWC_MIB_NAME)
         print("Successfully generated Clearwater Core MIB!")
     else:
-        print("No Clearwater Core MIB directory supplied, building Project "
-              "Clearwater MIB only")
-
-    # PC MIB fragment is found in the common directory, so supply common_dir
-    # as the extras directory also.
-    print("Generating Project Clearwater MIB at {}".format(common_dir))
-    generate_mib(common_dir,
-                 common_dir,
-                 output_dir,
-                 COMMON_MIB,
-                 PC_EXTRAS,
-                 PC_MIB_NAME)
-    print("Successfully generated Project Clearwater MIB!")
+        # PC MIB fragment is found in the common directory, so supply
+        # common_dir as the extras directory also.
+        print("Generating Project Clearwater MIB at {}".format(common_dir))
+        generate_mib(common_dir,
+                     common_dir,
+                     output_dir,
+                     COMMON_MIB,
+                     PC_EXTRAS,
+                     PC_MIB_NAME)
+        print("Successfully generated Project Clearwater MIB!")
 
 
 def generate_mib(common_dir,


### PR DESCRIPTION
@chris-elford-metaswitch could you review today if possible? If not, please reassign and let me know.

Small addition to cw_mib_generator.py to add argument specifying MIB output directory, as suggested by @richardwhiuk. Amends both script, and the Makefile to supply the output directory. This simplifies our build processes as it reduces the amount of copying around; we generate the MIB(s) directly where we want them.

In addition:
* I've moved the PC MIB generation into the if/else block for the `cwc-mib-dir` argument. Logic behind this is that I couldn't think of a scenario where we'd want to generate both at once. Please push back if you disagree here.
* Bunch of variable names changed to add clarity.