### PR TITLE
[Reviewer: EM] Increase smilint verification level to 6

### DIFF
--- a/mib-generator/cw_mib_generator.py
+++ b/mib-generator/cw_mib_generator.py
@@ -195,7 +195,7 @@ def verify_mib(common_dir, mib_path):
 
     smilint_conf = os.path.join(common_dir, "smilint.conf")
     try:
-        cmd = ['smilint', '-s', '-c', smilint_conf, mib_path]
+        cmd = ['smilint', '-s', '-l', '6', '-c', smilint_conf, mib_path]
 
         # If errors are found in the MIB but smilint doesn't exit abnormally,
         # then it still exits with code 0, so we also need to read the stderr


### PR DESCRIPTION
As you suggested, this increases our smilint verification level to 6. This should now catch all warnings, as well as errors.

Tested against the auto-generated PROJECT-CLEARWATER-MIB, which still passes. I then intentionally made a change that would generate a level 4 error, and it was correctly identified and rejected by smilint, which does not do so without this change.