### PR TITLE
[Reviewer: Seb] show_active_alarms requires the SNMP package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Package: clearwater-snmp-alarm-agent
 Architecture: any
 Breaks: clearwater-snmp-handler-alarm
 Replaces: clearwater-snmp-handler-alarm
-Depends: clearwater-snmpd, libboost-filesystem1.54.0
+Depends: clearwater-snmpd, snmp (= 5.7.2~dfsg-clearwater7), libboost-filesystem1.54.0
 Description: The SNMP subagent for Clearwater alarm reporting
 
 Package: clearwater-snmp-alarm-agent-dbg


### PR DESCRIPTION
Seb,

As discussed, showing the active alarms (using cw-show_active_alarms) requires the SNMP package.

You've tested that this works by manually installing snmp.