### PR TITLE
[Reviewer: Seb] Fix Boost Regex Linker Error

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -49,6 +49,7 @@ cw_alarm_fvtest_COVERAGE_EXCLUSIONS := ^modules/rapidjson|^modules/cpp-common/te
 AGENT_COMMON_LDFLAGS := -lzmq \
                         -lpthread \
                         -ldl \
+                        -lboost_regex \
                         -lboost_system \
                         -lboost_filesystem \
                         `net-snmp-config --agent-libs`


### PR DESCRIPTION
Seb,

Simple fix - same as Astaire - Metaswitch/cpp-common#680 adds a requirement on linking to boost_regex.