### PR TITLE
[Reviewer RJW2] Ensure wrapper death doesn't result in duplicate alarm agent processes

### DIFF
--- a/clearwater-snmp-alarm-agent.root/usr/share/clearwater/bin/clearwater-snmp-alarm-agent-wrapper
+++ b/clearwater-snmp-alarm-agent.root/usr/share/clearwater/bin/clearwater-snmp-alarm-agent-wrapper
@@ -33,6 +33,11 @@ get_daemon_args()
                --log-level=$log_level"
 }
 
+# Make sure that the alarm agent itself is not already running.
+# It might be, if the wrapper script was previously killed (by the OOM killer,
+# say) leaving the grandchild cw_alarm_agent process still running.
+pkill -9 -f -x '/usr/share/clearwater/bin/cw_alarm_agent.*'
+
 # /var/run/clearwater needs to exist so we can create a UNIX socket in it
 mkdir -p /var/run/clearwater
 

--- a/debian/clearwater-snmp-alarm-agent.upstart
+++ b/debian/clearwater-snmp-alarm-agent.upstart
@@ -10,10 +10,3 @@ post-stop exec sleep 5
 script
   /usr/share/clearwater/bin/clearwater-snmp-alarm-agent-wrapper
 end script
-
-# Be certain that the alarm agent itself is no longer running.
-# Otherwise, if the wrapper script is killed, the alarm agent
-# won't be, and we'll end up with two copies of it.
-post-stop script
-  pkill -9 -f -x '/usr/share/clearwater/bin/cw_alarm_agent.*' || true
-end script

--- a/debian/clearwater-snmp-alarm-agent.upstart
+++ b/debian/clearwater-snmp-alarm-agent.upstart
@@ -10,3 +10,10 @@ post-stop exec sleep 5
 script
   /usr/share/clearwater/bin/clearwater-snmp-alarm-agent-wrapper
 end script
+
+# Be certain that the alarm agent itself is no longer running.
+# Otherwise, if the wrapper script is killed, the alarm agent
+# won't be, and we'll end up with two copies of it.
+post-stop script
+  pkill -9 -f -x '/usr/share/clearwater/bin/cw_alarm_agent.*' || true
+end script


### PR DESCRIPTION
Hi Richard

Can you check that you're happy with this upstart change (and another in clearwater-infrastructure which I'll link).  This stems from a scary instance I've seen of an OOM killer wiping out the top level alarm agent wrapper process, with the result that upstart brought up a new copy of it, even though the cw_alarm_agent process (a grandchild of the original wrapper process) was still running, so we ended up with two alarm agents running.

I've tested that upstart operations (restart, stop, start etc) work as before, with the bonus that if the wrapper process is killed manually, we now get rid of the grandchild.

Note that I think the clearwater-infrastructure instances are the only other ones I could come up with.  The other clearwater-* upstart jobs exec their targets directly (rather than via wrapper scripts), so are not subject to this grandchilding,