### PR TITLE
[Reviewer: Adam] Add clearwater-snmp-alarm-agent-dbg to Makefile, so it gets included in repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ PKG_MAJOR_VERSION ?= 1.0
 
 # Define DEB_NAMES and RPM_NAMES separately as we don't have RPMs for all the
 # components yet.
-DEB_NAMES := clearwater-snmp-handler-cdiv clearwater-snmp-alarm-agent clearwater-snmp-handler-memento-as clearwater-snmp-handler-memento clearwater-snmp-handler-astaire
+DEB_NAMES := clearwater-snmp-handler-cdiv clearwater-snmp-alarm-agent clearwater-snmp-alarm-agent-dbg clearwater-snmp-handler-memento-as clearwater-snmp-handler-memento clearwater-snmp-handler-astaire
 RPM_NAMES := clearwater-snmp-alarm-agent
 
 # Add dependencies to deb-only and rpm-only (targets will be added by


### PR DESCRIPTION
Adam,

Just noticed the debug package was missing from `Makefile`, and hence from our repo.  Fix is trivial, and safe.

Having said that, we should hold off merging this until branches are cut next week.

Matt