### PR TITLE
[Reviewer: Richard] Fix UT race condition

### DIFF
--- a/src/ut/alarm_req_listener_test.cpp
+++ b/src/ut/alarm_req_listener_test.cpp
@@ -54,7 +54,7 @@ public:
     cwtest_completely_control_time();
 
     _alarm_table_defs = new AlarmTableDefs();
-    _alarm_scheduler = new MockAlarmScheduler(_alarm_table_defs, _snmp_notifications);
+    _alarm_scheduler = new MockAlarmScheduler(_alarm_table_defs, _snmp_notifications, _lock);
     _alarm_req_listener = new AlarmReqListener(_alarm_scheduler);
     _alarm_req_listener->start(NULL);
     _alarm_manager = new AlarmManager();
@@ -83,6 +83,7 @@ private:
   std::set<NotificationType> _snmp_notifications;
   CapturingTestLogger _log;
   AlarmTableDefs* _alarm_table_defs;
+  pthread_mutex_t _lock = PTHREAD_MUTEX_INITIALIZER;
   MockAlarmScheduler* _alarm_scheduler;
   AlarmReqListener* _alarm_req_listener;
   AlarmManager* _alarm_manager;
@@ -102,7 +103,7 @@ public:
     cwtest_intercept_zmq(&_mz);
 
     _alarm_table_defs = new AlarmTableDefs();
-    _alarm_scheduler = new MockAlarmScheduler(_alarm_table_defs, _snmp_notifications);
+    _alarm_scheduler = new MockAlarmScheduler(_alarm_table_defs, _snmp_notifications, _lock);
     _alarm_req_listener = new AlarmReqListener(_alarm_scheduler);
   }
 
@@ -122,6 +123,7 @@ private:
   int _c;
   int _s;
   AlarmTableDefs* _alarm_table_defs;
+  pthread_mutex_t _lock = PTHREAD_MUTEX_INITIALIZER;
   MockAlarmScheduler* _alarm_scheduler;
   AlarmReqListener* _alarm_req_listener;
 };

--- a/src/ut/mock_alarm_scheduler.h
+++ b/src/ut/mock_alarm_scheduler.h
@@ -19,11 +19,10 @@ class MockAlarmScheduler : public AlarmScheduler
 {
 public:
   MockAlarmScheduler(AlarmTableDefs* alarm_table_defs,
-                     std::set<NotificationType> snmp_notifications) :
-    AlarmScheduler(alarm_table_defs, snmp_notifications, "hostname1", _lock)
+                     std::set<NotificationType> snmp_notifications,
+                     pthread_mutex_t& lock) :
+    AlarmScheduler(alarm_table_defs, snmp_notifications, "hostname1", lock)
   {}
-
-  pthread_mutex_t _lock = PTHREAD_MUTEX_INITIALIZER;
 
   MOCK_METHOD2(issue_alarm, void(const std::string& issuer,
                                  const std::string& identifier));


### PR DESCRIPTION
This fixes the follow-on UT issue in https://github.com/Metaswitch/clearwater-issues/issues/2655.

I looked at whether we could rearrange initialization, but superclass constructors always happen before any member, so I just pulled constructing the lock out of MockAlarmScheduler.